### PR TITLE
CRM-46-Create-Metric-endpoints-and-calls: Created GET All endpoint for waste records metric

### DIFF
--- a/management_service/app/routers/index.ts
+++ b/management_service/app/routers/index.ts
@@ -7,3 +7,5 @@ export interface NamedRouter extends IRouter {
 export { default as ordersRouter } from "@server/routers/orders.router.js";
 export { default as stockRouter } from "@server/routers/stock.router.js";
 export { default as menuItemsRouter } from "@server/routers/menuItems.router.js";
+export { default as metricsRouter } from "@server/routers/metrics.router.js";
+

--- a/management_service/app/routers/metrics.router.ts
+++ b/management_service/app/routers/metrics.router.ts
@@ -1,0 +1,32 @@
+import { NamedRouter } from "./index.js";
+import { Router, Response } from "express";
+import { waste } from "@prisma/client";
+
+
+import { Db } from "@server/server.js";
+
+const metricsRouter = Router() as NamedRouter;
+metricsRouter.prefix = "metrics";
+
+// GET All Waste records for frontend waste table | Excluding req:Request
+metricsRouter.get("/", async (_, res: Response) => {
+  try{
+    let wasteRecords:waste[] = [];
+    console.log("Retrieving Waste metrics: ");
+     // Fetch waste records along with stock and ingredient details
+    wasteRecords = await Db.waste.findMany();
+
+     // Respond with the retrieved waste records
+    res.status(200).json({
+      waste: wasteRecords,
+    });
+   }catch (error){
+    // Logged Error
+    console.error("Error retrieving waste metrics:", error);
+    res.status(500).json({ error: "Internal server error" });
+   }
+});
+
+// Will include other metrics later once identified 
+
+export default metricsRouter;

--- a/management_service/app/server.ts
+++ b/management_service/app/server.ts
@@ -1,6 +1,6 @@
 import express from "express";
 import cors from "cors";
-import { NamedRouter, ordersRouter, stockRouter, menuItemsRouter} from "@server/routers/index.js";
+import { NamedRouter, ordersRouter, stockRouter, menuItemsRouter, metricsRouter} from "@server/routers/index.js";
 import { PrismaClient } from "@prisma/client";
 
 // SINGLE INSTANCE OF PRISMA CLIENT that gets exported and used in all routers as opposed to creating a new instance in each router
@@ -21,7 +21,7 @@ server.use(express.urlencoded({ extended: true }));
 server.use(cors());
 
 const PublicAPIs: NamedRouter[] = [
-  ordersRouter, stockRouter, menuItemsRouter
+  ordersRouter, stockRouter, menuItemsRouter, metricsRouter
   // Add more routers here as needed
 
 ];


### PR DESCRIPTION
Created Waste Route (GET /waste):

Retrieves all records from the waste table.
Includes associated stock details (ingredient information) for improved traceability.

Data Returned:

![2025-03-16_18h17_14](https://github.com/user-attachments/assets/3135e9cf-6aeb-4c91-9aab-1b2e4dc5fd21)
