### PR TITLE
CRM-119-backend-create-db-calls-for-profit-metrics

### DIFF
--- a/management_service/app/DB/sql/orderItems/findTopOrWorstSeller.sql
+++ b/management_service/app/DB/sql/orderItems/findTopOrWorstSeller.sql
@@ -1,0 +1,11 @@
+SELECT 
+	menuitems.name,
+	COUNT(menuitems.menuitemid) AS totalSaleCount
+FROM
+	orderitems
+	INNER JOIN menuitems USING (menuitemid)
+WHERE orderitems.servedtimestamp >= (CURRENT_DATE - '7 days'::interval)
+GROUP BY
+	menuitems.name
+ORDER BY totalSaleCount DESC/ASC
+LIMIT 1;

--- a/management_service/app/DB/sql/views/profits/profit_view_one_year.sql
+++ b/management_service/app/DB/sql/views/profits/profit_view_one_year.sql
@@ -1,12 +1,8 @@
 CREATE MATERIALIZED VIEW IF NOT EXISTS profit_view_one_year
 AS
-SELECT
-  SUM(menuitems.price) - (
-    SELECT
-      SUM(expenses.amount)
-    FROM
-      expenses
-    ) AS profit
-FROM
-  menuitems INNER JOIN orderitems on menuitems.menuitemid = orderitems.menuitemid
-WHERE servedtimestamp >= current_date - interval '1 year';
+ SELECT COALESCE(( SELECT sum(menuitems.price) AS sum
+           FROM menuitems
+             JOIN orderitems ON menuitems.menuitemid = orderitems.menuitemid
+          WHERE orderitems.servedtimestamp::date >= (CURRENT_DATE - '1 year'::interval)), 0::numeric) - COALESCE(( SELECT sum(expenses.amount) AS sum
+           FROM expenses
+          WHERE expenses.expensedate::date >= (CURRENT_DATE - '1 year'::interval)), 0::numeric) AS profit;

--- a/management_service/app/DB/sql/views/profits/profit_view_seven_days.sql
+++ b/management_service/app/DB/sql/views/profits/profit_view_seven_days.sql
@@ -1,12 +1,8 @@
 CREATE MATERIALIZED VIEW IF NOT EXISTS profit_view_seven_days
 AS
-SELECT
-  SUM(menuitems.price) - (
-    SELECT
-      SUM(expenses.amount)
-    FROM
-      expenses
-    ) AS profit
-FROM
-  menuitems INNER JOIN orderitems on menuitems.menuitemid = orderitems.menuitemid
-WHERE servedtimestamp >= current_date - interval '7 days';
+ SELECT COALESCE(( SELECT sum(menuitems.price) AS sum
+           FROM menuitems
+             JOIN orderitems ON menuitems.menuitemid = orderitems.menuitemid
+          WHERE orderitems.servedtimestamp::date >= (CURRENT_DATE - '7 days'::interval)), 0::numeric) - COALESCE(( SELECT sum(expenses.amount) AS sum
+           FROM expenses
+          WHERE expenses.expensedate::date >= (CURRENT_DATE - '7 days'::interval)), 0::numeric) AS profit;

--- a/management_service/app/DB/sql/views/profits/profti_view_today.sql
+++ b/management_service/app/DB/sql/views/profits/profti_view_today.sql
@@ -1,13 +1,10 @@
 CREATE MATERIALIZED VIEW IF NOT EXISTS profit_view_today
 AS
-SELECT
-  SUM(menuitems.price) - (
-    SELECT
-      SUM(expenses.amount)
-    FROM
-      expenses
-    ) AS profit
-FROM
-  menuitems INNER JOIN orderitems on menuitems.menuitemid = orderitems.menuitemid
-WHERE servedtimestamp >= current_date;
+ SELECT COALESCE(( SELECT sum(menuitems.price) AS sum
+           FROM menuitems
+             JOIN orderitems ON menuitems.menuitemid = orderitems.menuitemid
+          WHERE orderitems.servedtimestamp::date >= CURRENT_DATE), 0::numeric) - 
+          COALESCE(( SELECT sum(expenses.amount) AS sum
+           FROM expenses
+          WHERE expenses.expensedate::date >= CURRENT_DATE), 0::numeric) AS profit;
 


### PR DESCRIPTION
- Create a new file for the SQL query to find the top or worst seller in a time period
- Modify the SQL profit views for profit metrics to account for null values
- Modify the metrics router to include the new DB queries for top or worst seller
- Modify the metrics router to include the new DB queries for profit metrics
- Modify the metrics router to include the new DB queries for order metrics