### PR TITLE
Crm 141 fe improve the pos starting state and add visual cues for order manipulation

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -9,6 +9,7 @@
   --active-button-color: #6063ff;
   --remove-button-bg-color: #a760ff;
   --custom-active-red-color: #ea484b;
+  --continue-button-color: #DE5BFF;
   --drop-shadow-color: hsla(221, 71%, 64%, 0.293);
   --white-backdrop: rgba(255, 255, 255, 0.573);
   --rows-drop-shadow: 0 2px 2px 1px var(--drop-shadow-color);

--- a/frontend/src/app/pos/page.tsx
+++ b/frontend/src/app/pos/page.tsx
@@ -16,7 +16,7 @@ export default function POS() {
   const fetchString = "menuItems";
   const { data } = useFetch<{ menuItems: MenuItemType[] }>(fetchString);
   const [addedItems, setAddedItems] = useState<ItemProps[]>([]);
-  const [isCartVisible, setIsCartVisible] = useState(false);
+  const [isCartVisible, setIsCartVisible] = useState(true);
   const { currentSelection, isCurrentSelection, setCurrentSelection } =
     useSelection();
   const menuItems = data?.menuItems;
@@ -74,11 +74,15 @@ export default function POS() {
 
   const svgSize = 20;
   const amountOfItemsInCart = addedItems.reduce((prevVal, currVal) => prevVal + (currVal.quantity ?? 0), 0)
+  const findElement =(item: MenuItemType)=>{
+    return addedItems.find(searchedItem => searchedItem.foodName === item.name)
+  }
   console.table(menuItems);
   return (
     <div className="main-container pos-container">
       <button
-        className="btn btn-square relative text-[--foreground] self-end mr-[20px] bg-[--background] hover:bg-[--foreground] hover:text-white border-[--foreground] mt-[20px]"
+        className={`btn btn-square relative text-[--foreground] self-end mr-[20px]
+         bg-[--background] hover:bg-[--foreground] hover:text-white border-[--foreground] mt-[20px] `}
         onClick={() => setIsCartVisible((prevVisibility) => !prevVisibility)}
         aria-label="Cart toggle button"
       >
@@ -94,11 +98,14 @@ export default function POS() {
             fill="currentColor"
           />
         </svg>
-        { addedItems.length > 0 && <span className="flex justify-center absolute w-[30px] text-[--foreground]
-        h-[30px] bottom-[-20px] left-[-18px] bg-white outline rounded-[50%]">
-            <span className="self-center text-[--custom-active-red-color] pointer-events-none">{amountOfItemsInCart}</span>
+        { addedItems.length > 0 && <span key={amountOfItemsInCart} className={`flex justify-center absolute w-[30px] text-[--foreground]
+        h-[30px] bottom-[-20px] left-[-18px] bg-white outline rounded-[50%] ${menuItemStyles["elem-bounce"]}`}>
+            <span  className={`self-center text-[--custom-active-red-color] pointer-events-none`}>{amountOfItemsInCart}</span>
           </span>}
       </button>
+      <span className={styles["restaurant-current-option-title"]}>
+            <span>{currentSelection === "none" ? "All" : currentSelection}</span> Menu
+          </span>
       <div className={styles["restaurant-sub-menu-container"]}>
         {menuCategories.map((menuItem, index) => {
           return (
@@ -113,10 +120,10 @@ export default function POS() {
         })}
       </div>
 
-      <span className="flex outline gap-[2rem] w-full justify-between place-items-center ml-[-20px] p-[20px] mt-[20px]">
+      <span className="flex gap-[2rem] w-full justify-center place-items-center ml-[-20px] p-[20px] mt-[20px]">
         <span
           className="grid grid-flow-row-dense tablet:grid-cols-2 mobile:grid-cols-1 
-          p-[20px] grid-cols-6 gap-[20px] max-h-[400px] overflow-y-auto"
+          p-[20px] grid-cols-4 gap-[20px] max-h-[600px] overflow-y-auto"
         >
           {filteredMenuItems?.map((item, index) => {
             const imgSize = 80;
@@ -138,7 +145,7 @@ export default function POS() {
                   <span>Price: ${item.price}</span>                  
                 </span>
                 <button
-                  className="btn tablet:text-[0.7rem] rounded-none"
+                  className="btn tablet:text-[0.7rem] rounded-none h-full"
                   onClick={() => {
                     const newItem: ItemProps = {
                       foodName: item.name,
@@ -160,6 +167,13 @@ export default function POS() {
                 >
                   Add Item
                 </button>
+                { 
+                  findElement(item)?.quantity &&
+                  <span key={findElement(item)?.quantity} className={`${menuItemStyles["elem-bounce"]} ${menuItemStyles["number-indicator"]}`}
+                  >
+                    <span>{(findElement(item)?.quantity)}</span>
+                  </span>
+                }
               </span>
             );
           })}

--- a/frontend/src/app/pos/page.tsx
+++ b/frontend/src/app/pos/page.tsx
@@ -1,60 +1,53 @@
-"use client"
-import Cart, { CartInfo, ItemProps } from '@/components/POS/Cart'
-import { useFetch } from '@/customHooks/useFetch'
-import { useState } from 'react'
-import useSelection from '@/customHooks/useSelection'
-import type { MenuItemType } from '@/components/MenuManagementContainer'
-import SelectableButton from '@/components/SelectableButton'
-import styles from "../../styles/MenuManagementContainer.module.css"
-import Image from 'next/image'
-import { useMutation } from '@/customHooks/useMutation'
+"use client";
+import Cart, { CartInfo, ItemProps } from "@/components/POS/Cart";
+import { useFetch } from "@/customHooks/useFetch";
+import { useState } from "react";
+import useSelection from "@/customHooks/useSelection";
+import { MenuItemType } from "@/components/MenuManagementContainer";
+import SelectableButton from "@/components/SelectableButton";
+import styles from "../../styles/MenuManagementContainer.module.css";
+import menuItemStyles from "../../styles/MenuItem.module.css"
+import Image from "next/image";
 
 const menuCategories =
-  "Popular, Meals, Entrees, Salads, Sides, Beverages".split(
-    ","
-  );
+  "Popular, Meals, Entrees, Salads, Sides, Beverages".split(",");
 menuCategories.forEach((menuCategory) => menuCategory.trimStart());
 export default function POS() {
-
   const fetchString = "menuItems";
   const { data } = useFetch<{ menuItems: MenuItemType[] }>(fetchString);
-  const { updateData: updateOrder } = useMutation("POST", "orders");
-  const [addedItems, setAddedItems] = useState<ItemProps[]>([])
-  const [isCartVisible, setIsCartVisible] = useState(false)
-  const { currentSelection, isCurrentSelection, setCurrentSelection } = useSelection();
-  const menuItems = data?.menuItems
-
-
-
-  const cancelOrder = () => setAddedItems([])
+  const [addedItems, setAddedItems] = useState<ItemProps[]>([]);
+  const [isCartVisible, setIsCartVisible] = useState(false);
+  const { currentSelection, isCurrentSelection, setCurrentSelection } =
+    useSelection();
+  const menuItems = data?.menuItems;
+  const cancelOrder = () => setAddedItems([]);
   const increaseItemQty = (itemName: string) => {
-    const items = [...addedItems]
-    const itemIndex = items.findIndex(item => item.foodName === itemName)
+    const items = [...addedItems];
+    const itemIndex = items.findIndex((item) => item.foodName === itemName);
     if (items[itemIndex] && items[itemIndex].quantity) {
       items[itemIndex].quantity += 1;
-      setAddedItems([...items])
+      setAddedItems([...items]);
     }
-  }
+  };
   const decreaseItemQty = (itemName: string) => {
-    const items = [...addedItems]
-    const itemIndex = items.findIndex(item => item.foodName === itemName)
-    if (items[itemIndex] && items[itemIndex].quantity && items[itemIndex].quantity > 1) {
+    const items = [...addedItems];
+    const itemIndex = items.findIndex((item) => item.foodName === itemName);
+    if (
+      items[itemIndex] &&
+      items[itemIndex].quantity &&
+      items[itemIndex].quantity > 1
+    ) {
       items[itemIndex].quantity -= 1;
-      setAddedItems([...items])
+      setAddedItems([...items]);
     }
-  }
-  const continueOrder = async () => {
-    console.log(addedItems)
-    const res = await updateOrder({ orderItems: addedItems })
-    if (res.success) {
-      setAddedItems([])
-    }
-  }
-
+  };
+  const continueOrder = () => {};
   const removeItemFromCart = (itemName: string) => {
-    const filteredItems = addedItems.filter(item => item.foodName !== itemName)
-    setAddedItems([...filteredItems])
-  }
+    const filteredItems = addedItems.filter(
+      (item) => item.foodName !== itemName
+    );
+    setAddedItems([...filteredItems]);
+  };
 
   const cartInfo: CartInfo = {
     orderid: 939820,
@@ -62,30 +55,49 @@ export default function POS() {
     itemActions: {
       increaseQty: increaseItemQty,
       decreaseQty: decreaseItemQty,
-      removeItem: removeItemFromCart
+      removeItem: removeItemFromCart,
     },
     continueOrder: continueOrder,
-    cancelOrder: cancelOrder
-  }
+    cancelOrder: cancelOrder,
+  };
 
   const filteredMenuItems =
     currentSelection === "none"
       ? menuItems
-      : menuItems?.filter(item => {
-        const optionName = currentSelection.toLowerCase().trim();
-        if (optionName === "popular") {
-          return item.isPopular === true;
-        }
-        return item.category.toLowerCase() === optionName;
-      });
+      : menuItems?.filter((item) => {
+          const optionName = currentSelection.toLowerCase().trim();
+          if (optionName === "popular") {
+            return item.isPopular === true;
+          }
+          return item.category.toLowerCase() === optionName;
+        });
 
-
-  const svgSize = 20
-  // console.table(menuItems)
+  const svgSize = 20;
+  const amountOfItemsInCart = addedItems.reduce((prevVal, currVal) => prevVal + (currVal.quantity ?? 0), 0)
+  console.table(menuItems);
   return (
     <div className="main-container pos-container">
-      <button className="btn btn-square text-[--foreground] self-end mr-[20px] bg-[--background] hover:bg-[--foreground] hover:text-white border-[--foreground] mt-[20px]" onClick={() => setIsCartVisible(prevVisibility => !prevVisibility)}>
-        <svg width={svgSize} height={svgSize} viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M4 .75H1a1 1 0 0 0-1 1v.5a1 1 0 0 0 1 1h2.012l2.724 11.481A4.25 4.25 0 0 0 9.765 18h7.822a4 4 0 0 0 3.943-3.325l1.256-7.338A2 2 0 0 0 20.814 5H5.997l-.78-3.289A1.25 1.25 0 0 0 4 .75M10 21a2 2 0 1 1-4 0 2 2 0 0 1 4 0m11 0a2 2 0 1 1-4 0 2 2 0 0 1 4 0" fill="currentColor" /></svg>
+      <button
+        className="btn btn-square relative text-[--foreground] self-end mr-[20px] bg-[--background] hover:bg-[--foreground] hover:text-white border-[--foreground] mt-[20px]"
+        onClick={() => setIsCartVisible((prevVisibility) => !prevVisibility)}
+        aria-label="Cart toggle button"
+      >
+        <svg
+          width={svgSize}
+          height={svgSize}
+          viewBox="0 0 24 24"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M4 .75H1a1 1 0 0 0-1 1v.5a1 1 0 0 0 1 1h2.012l2.724 11.481A4.25 4.25 0 0 0 9.765 18h7.822a4 4 0 0 0 3.943-3.325l1.256-7.338A2 2 0 0 0 20.814 5H5.997l-.78-3.289A1.25 1.25 0 0 0 4 .75M10 21a2 2 0 1 1-4 0 2 2 0 0 1 4 0m11 0a2 2 0 1 1-4 0 2 2 0 0 1 4 0"
+            fill="currentColor"
+          />
+        </svg>
+        { addedItems.length > 0 && <span className="flex justify-center absolute w-[30px] text-[--foreground]
+        h-[30px] bottom-[-20px] left-[-18px] bg-white outline rounded-[50%]">
+            <span className="self-center text-[--custom-active-red-color] pointer-events-none">{amountOfItemsInCart}</span>
+          </span>}
       </button>
       <div className={styles["restaurant-sub-menu-container"]}>
         {menuCategories.map((menuItem, index) => {
@@ -102,40 +114,58 @@ export default function POS() {
       </div>
 
       <span className="flex outline gap-[2rem] w-full justify-between place-items-center ml-[-20px] p-[20px] mt-[20px]">
-        <span className="grid grid-flow-row-dense tablet:grid-cols-2 mobile:grid-cols-1 
-          p-[20px] grid-cols-6 gap-[20px] max-h-[400px] overflow-y-auto" >
-          {
-            filteredMenuItems?.map((item, index) => {
-              const imgSize = 100;
-              return (
-                <span className="flex flex-col p-[10px] bg-white outline rounded-md place-content-center" key={index}>
-                  <Image src={item.pictureUrl} width={imgSize} height={imgSize} alt={item.name} />
-                  <span className="tablet:text-[0.7rem] text-center">{item.name}</span>
-                  <span className="flex flex-col">
-                    <span>Price:</span>
-                    <span>${item.price}</span>
-                  </span>
-                  <button className="btn tablet:text-[0.7rem]" onClick={() => {
-                    const newItem: ItemProps = { foodName: item.name, foodPrice: parseFloat(item.price), quantity: 1, id: item.menuitemid };
-                    const allItems = [...addedItems]
-                    const itemFoundIndex = allItems.findIndex(item => item.foodName === newItem.foodName)
-                    if (itemFoundIndex >= 0 && itemFoundIndex < allItems.length && allItems[itemFoundIndex]?.quantity !== undefined) {
-                      allItems[itemFoundIndex].quantity += 1
-                      setAddedItems([...allItems])
-                    }
-                    else {
-                      setAddedItems(prevItems => [...prevItems, newItem])
-                    }
-
-                  }}>Add Item</button>
+        <span
+          className="grid grid-flow-row-dense tablet:grid-cols-2 mobile:grid-cols-1 
+          p-[20px] grid-cols-6 gap-[20px] max-h-[400px] overflow-y-auto"
+        >
+          {filteredMenuItems?.map((item, index) => {
+            const imgSize = 80;
+            return (
+              <span
+                className={menuItemStyles["pos-menu-item"]}
+                key={index}
+              >
+                <Image
+                  src={item.pictureUrl}
+                  width={imgSize}
+                  height={imgSize}
+                  alt={item.name}
+                />
+                <span className="tablet:text-[0.7rem] text-center">
+                  {item.name}
                 </span>
-              )
-            })
-          }
+                <span className="flex flex-col">
+                  <span>Price: ${item.price}</span>                  
+                </span>
+                <button
+                  className="btn tablet:text-[0.7rem]"
+                  onClick={() => {
+                    const newItem: ItemProps = {
+                      foodName: item.name,
+                      foodPrice: parseFloat(item.price),
+                      quantity: 1,
+                    };
+                    const allItems = [...addedItems];
+                    const itemFoundIndex = allItems.findIndex(
+                      (item) => item.foodName === newItem.foodName
+                    );
+                    if (itemFoundIndex >= 0 && itemFoundIndex < allItems.length 
+                      && allItems[itemFoundIndex]?.quantity !== undefined) {
+                      allItems[itemFoundIndex].quantity += 1;
+                      setAddedItems([...allItems]);
+                    } else {
+                      setAddedItems((prevItems) => [...prevItems, newItem]);
+                    }
+                  }}
+                >
+                  Add Item
+                </button>
+              </span>
+            );
+          })}
         </span>
         {isCartVisible && <Cart {...cartInfo} />}
       </span>
     </div>
-  )
+  );
 }
-

--- a/frontend/src/app/pos/page.tsx
+++ b/frontend/src/app/pos/page.tsx
@@ -8,6 +8,8 @@ import SelectableButton from "@/components/SelectableButton";
 import styles from "../../styles/MenuManagementContainer.module.css";
 import menuItemStyles from "../../styles/MenuItem.module.css"
 import Image from "next/image";
+import { svgIcons } from "../svgIcons";
+import Link from "next/link";
 
 const menuCategories =
   "Popular, Meals, Entrees, Salads, Sides, Beverages".split(",");
@@ -72,7 +74,6 @@ export default function POS() {
           return item.category.toLowerCase() === optionName;
         });
 
-  const svgSize = 20;
   const amountOfItemsInCart = addedItems.reduce((prevVal, currVal) => prevVal + (currVal.quantity ?? 0), 0)
   const findElement =(item: MenuItemType)=>{
     return addedItems.find(searchedItem => searchedItem.foodName === item.name)
@@ -80,32 +81,26 @@ export default function POS() {
   console.table(menuItems);
   return (
     <div className="main-container pos-container">
+      <h1 className="text-[2rem] font-semibold my-[2rem]">POS</h1>
+      <Link href="/select-portal">
+        <button className="flex btn fixed right-[100px] top-[20px] bg-transparent hover:bg-[--foreground] hover:border-none
+        w-[fit-content] text-[--foreground] border-[--foreground] hover:text-[white]">
+            {svgIcons.backArrow}
+        </button>
+      </Link>
       <button
-        className={`btn btn-square relative text-[--foreground] self-end mr-[20px]
+        className={`fixed top-[0px] btn btn-square text-[--foreground] self-end mr-[20px]
          bg-[--background] hover:bg-[--foreground] hover:text-white border-[--foreground] mt-[20px] `}
         onClick={() => setIsCartVisible((prevVisibility) => !prevVisibility)}
         aria-label="Cart toggle button"
       >
-        <svg
-          width={svgSize}
-          height={svgSize}
-          viewBox="0 0 24 24"
-          fill="none"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M4 .75H1a1 1 0 0 0-1 1v.5a1 1 0 0 0 1 1h2.012l2.724 11.481A4.25 4.25 0 0 0 9.765 18h7.822a4 4 0 0 0 3.943-3.325l1.256-7.338A2 2 0 0 0 20.814 5H5.997l-.78-3.289A1.25 1.25 0 0 0 4 .75M10 21a2 2 0 1 1-4 0 2 2 0 0 1 4 0m11 0a2 2 0 1 1-4 0 2 2 0 0 1 4 0"
-            fill="currentColor"
-          />
-        </svg>
+        {svgIcons.cart}
         { addedItems.length > 0 && <span key={amountOfItemsInCart} className={`flex justify-center absolute w-[30px] text-[--foreground]
         h-[30px] bottom-[-20px] left-[-18px] bg-white outline rounded-[50%] ${menuItemStyles["elem-bounce"]}`}>
             <span  className={`self-center text-[--custom-active-red-color] pointer-events-none`}>{amountOfItemsInCart}</span>
           </span>}
       </button>
-      <span className={styles["restaurant-current-option-title"]}>
-            <span>{currentSelection === "none" ? "All" : currentSelection}</span> Menu
-          </span>
+      
       <div className={styles["restaurant-sub-menu-container"]}>
         {menuCategories.map((menuItem, index) => {
           return (
@@ -119,6 +114,9 @@ export default function POS() {
           );
         })}
       </div>
+      <span className={`${styles["restaurant-current-option-title-pos"]}`}>
+            <span>{currentSelection === "none" ? "All" : currentSelection}</span> Menu
+      </span>
 
       <span className="flex gap-[2rem] w-full justify-center place-items-center ml-[-20px] p-[20px] mt-[20px]">
         <span

--- a/frontend/src/app/pos/page.tsx
+++ b/frontend/src/app/pos/page.tsx
@@ -138,7 +138,7 @@ export default function POS() {
                   <span>Price: ${item.price}</span>                  
                 </span>
                 <button
-                  className="btn tablet:text-[0.7rem]"
+                  className="btn tablet:text-[0.7rem] rounded-none"
                   onClick={() => {
                     const newItem: ItemProps = {
                       foodName: item.name,

--- a/frontend/src/app/svgIcons.tsx
+++ b/frontend/src/app/svgIcons.tsx
@@ -336,6 +336,31 @@ const svgIcons = {
       />
     </svg>
   ),
+  backArrow:
+  <svg
+    width="15px"
+    height="32px"
+    viewBox="0 0 512 512"
+    id="Layer_1"
+    xmlSpace="preserve"
+    xmlns="http://www.w3.org/2000/svg"
+    xmlnsXlink="http://www.w3.org/1999/xlink"
+  >
+    <path fill="currentColor" d="M297.2,478l20.7-21.6L108.7,256L317.9,55.6L297.2,34L65.5,256L297.2,478z M194.1,256L425.8,34l20.7,21.6L237.3,256  l209.2,200.4L425.8,478L194.1,256z" />
+  </svg>,
+  cart:
+  <svg
+      width={20}
+      height={20}
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M4 .75H1a1 1 0 0 0-1 1v.5a1 1 0 0 0 1 1h2.012l2.724 11.481A4.25 4.25 0 0 0 9.765 18h7.822a4 4 0 0 0 3.943-3.325l1.256-7.338A2 2 0 0 0 20.814 5H5.997l-.78-3.289A1.25 1.25 0 0 0 4 .75M10 21a2 2 0 1 1-4 0 2 2 0 0 1 4 0m11 0a2 2 0 1 1-4 0 2 2 0 0 1 4 0"
+        fill="currentColor"
+      />
+  </svg>
 };
 const notificationIcons = {
   error: (

--- a/frontend/src/components/POS/Cart.tsx
+++ b/frontend/src/components/POS/Cart.tsx
@@ -1,91 +1,96 @@
 "use client"
-export interface CartContextType {
-  cancelOrder: () => void;
+import styles from "../../styles/Cart.module.css"
+export interface CartContextType{
+  cancelOrder: ()=> void;
 }
 export interface MenuItem {
   menuitemid: number;
   customizationdetail: string | null
 }
-export interface ItemButtonActions {
-  decreaseQty: (itemName: string) => void;
-  increaseQty: (itemName: string) => void;
-  removeItem: (itemName: string) => void;
+export interface ItemButtonActions{
+  decreaseQty: (itemName: string)=>void;
+  increaseQty: (itemName: string)=>void;
+  removeItem:  (itemName: string)=>void;
 }
-export interface CartInfo {
-  orderid: number;
-  items: ItemProps[];
-  continueOrder: () => void;
-  cancelOrder: () => void;
-  itemActions: ItemButtonActions;
+export interface CartInfo{
+    orderid: number;
+    items: ItemProps[];
+    continueOrder: ()=>void;
+    cancelOrder: ()=>void;
+    itemActions: ItemButtonActions;
 }
-export interface POSMenuItem {
+export interface POSMenuItem{    
   category: string;
   createdat: string;
-  isPopular: boolean;
+  isPopular : boolean;
   menuitemid: number;
   name: string;
   pictureUrl: string;
   price: string;
   profit: string;
-  updatedat: string;
+  updatedat : string;
 }
 
-export interface ItemProps {
+export interface ItemProps{
   foodName: string;
-  id: string;
   foodPrice: number;
   quantity?: number;
   actions?: ItemButtonActions;
 }
 export default function Cart(orderInfo: CartInfo) {
-  const cartTotalCost = orderInfo.items.reduce((prevVal, currVal) => prevVal + (currVal.quantity ? (currVal.foodPrice * currVal.quantity) : currVal.foodPrice), 0).toFixed(2)
+  const cartTotalCost = orderInfo.items.reduce((prevVal, currVal)=> prevVal + (currVal.quantity? (currVal.foodPrice * currVal.quantity): currVal.foodPrice), 0).toFixed(2)
   return (
-    <div className="flex flex-col px-[40px] gap-[1rem] py-[20px] rounded-[8px] max-w-[500px] min-w-[300px] bg-white h-[500px] outline">
-      <span className="max-h-[fit-content] text-2xl">Cart</span>
-      <span className="flex flex-col h-[200px] overflow-y-auto">
+    <div className={styles["cart-container"]}>
+      <span className={styles["cart-title"]}>Cart</span>
+      <span className="flex flex-col h-[400px] gap-[10px] overflow-y-auto">
         {
-          orderInfo.items?.map((item, index) => {
-            const currItem: ItemProps = {
-              foodName: item.foodName,
-              foodPrice: item.foodPrice,
-              quantity: item.quantity,
-              actions: orderInfo.itemActions,
-              id: item.id
-            }
-            return (
-              <ItemComponent key={index} {...currItem} />
-            )
-          })
+            orderInfo.items?.map((item, index)=>{
+                const currItem: ItemProps={
+                    foodName: item.foodName,
+                    foodPrice: item.foodPrice,
+                    quantity: item.quantity,
+                    actions: orderInfo.itemActions
+                }
+                return(
+                    <ItemComponent key={index} {...currItem} />
+                )
+            })
         }
       </span>
       <span className="flex flex-col">
-        <span className="flex justify-between">
-          <span>Total</span>
-          <span>${cartTotalCost}</span>
+        <span className="flex justify-between text-[1.4rem] text-black pb-[10px]">
+            <span>Total</span>
+            <span>${cartTotalCost}</span>
         </span>
         <span className="grid grid-rows-2 w-full gap-[1rem]">
-          <button className="btn btn-success text-white" onClick={orderInfo.continueOrder}>Continue</button>
-          <button className="btn btn-error text-white" onClick={() => orderInfo.cancelOrder()}>Cancel</button>
+            <button className="btn bg-[--continue-button-color] border-none hover:bg-purple-500 active:bg-[--foreground-2] text-white">Buy</button>
+            <button className="btn btn-error text-white" onClick={()=>orderInfo.cancelOrder()}>Cancel</button>
         </span>
       </span>
     </div>
   );
 }
-const ItemComponent = (itemInfo: ItemProps) => {
-  return (
-    <span className="grid grid-rows-2 h-[100px]">
-      <span className="flex justify-between">
-        <h1 className="text-lg">{itemInfo.foodName}</h1>
-        <h3>${itemInfo.quantity ? (itemInfo.foodPrice * itemInfo.quantity).toFixed(2) : itemInfo.foodPrice}</h3>
-        <span>
-          <span>Qty: {itemInfo.quantity}</span>
-          <button className="btn btn-outline btn-primary" onClick={() => itemInfo.actions?.increaseQty(itemInfo.foodName)}>+</button>
-          <button className="btn btn-outline btn-secondary" onClick={() => itemInfo.actions?.decreaseQty(itemInfo.foodName)}>-</button>
+const ItemComponent=(itemInfo: ItemProps)=>{
+    return(
+        <span className="grid grid-rows-2 h-[100px] py-[10px] px-[10px] mb-[5px]">
+            <span className="flex justify-between">
+                <span className="flex flex-col">
+                  <span className={styles["pos-item-name"]}>{itemInfo.foodName}</span>
+                  <span>${itemInfo.quantity? (itemInfo.foodPrice * itemInfo.quantity).toFixed(2): itemInfo.foodPrice}</span>
+                </span>
+                <span className="flex items-center">
+                  <span className="pr-[10px]">{itemInfo.quantity}</span>
+                  <span className="flex relative gap-[4px]">
+                    <button className="btn btn-outline btn-primary"   onClick={()=>itemInfo.actions?.increaseQty(itemInfo.foodName)}>+</button>
+                    <button className="btn btn-outline btn-secondary" onClick={()=>itemInfo.actions?.decreaseQty(itemInfo.foodName)}>-</button>
+                  </span>
+                </span>
+            </span>
+            <span className="flex justify-end mt-[5px]">
+              <button className="btn btn-outline 
+              bg-[--remove-button-bg-color] hover:bg-none hover:outline-[--remove-button-bg-color]
+               text-white" onClick={()=>itemInfo.actions?.removeItem(itemInfo.foodName)}>Remove</button>
+            </span>
         </span>
-      </span>
-      <span className="flex justify-between">
-        <button className="btn btn-outline bg-[--remove-button-bg-color] hover:bg-none hover:outline-[--remove-button-bg-color] text-white" onClick={() => itemInfo.actions?.removeItem(itemInfo.foodName)}>Remove</button>
-      </span>
-    </span>
-  )
+    )
 }

--- a/frontend/src/styles/Cart.module.css
+++ b/frontend/src/styles/Cart.module.css
@@ -2,6 +2,7 @@
     @apply flex fixed right-[10px] flex-col px-[40px] gap-[1rem];
     @apply py-[20px] rounded-[8px] max-w-[500px] min-w-[300px] bg-white h-[80%] outline;
     @apply justify-evenly top-[100px];
+    z-index: 10;
     
 }
 .pos-item-name{

--- a/frontend/src/styles/Cart.module.css
+++ b/frontend/src/styles/Cart.module.css
@@ -1,7 +1,7 @@
 .cart-container{
     @apply flex fixed right-[10px] flex-col px-[40px] gap-[1rem];
     @apply py-[20px] rounded-[8px] max-w-[500px] min-w-[300px] bg-white h-[80%] outline;
-    @apply justify-evenly;
+    @apply justify-evenly top-[100px];
     
 }
 .pos-item-name{

--- a/frontend/src/styles/Cart.module.css
+++ b/frontend/src/styles/Cart.module.css
@@ -1,0 +1,12 @@
+.cart-container{
+    @apply flex fixed right-[10px] flex-col px-[40px] gap-[1rem];
+    @apply py-[20px] rounded-[8px] max-w-[500px] min-w-[300px] bg-white h-[80%] outline;
+    @apply justify-evenly;
+    
+}
+.pos-item-name{
+    @apply text-lg max-w-[200px];
+}
+.cart-title{
+    @apply max-h-[fit-content] text-2xl text-black text-[2rem] font-semibold;
+}

--- a/frontend/src/styles/MenuItem.module.css
+++ b/frontend/src/styles/MenuItem.module.css
@@ -4,7 +4,7 @@
     @apply mobile:max-w-[100%];
 }
 .pos-menu-item{
-    @apply grid relative place-items-center rounded-[6px] flex-col max-w-[160px] h-[200px] p-[20px] bg-[white] overflow-y-clip gap-[4px] justify-between;
+    @apply grid relative place-items-center rounded-[6px] flex-col max-w-[160px] h-[200px] p-[20px] bg-[white] overflow-clip gap-[4px] justify-between;
     box-shadow: 0 0px 4px 2px var(--drop-shadow-color);
     @apply mobile:max-w-[100%];
     
@@ -16,8 +16,14 @@
     }
     transition: margin 0.3s ease;
 }
+.pos-menu-item button {
+    @apply mb-[-140%];
+    transition: margin 0.13s ease-in-out;
+}
 .menuItem:hover button , .pos-menu-item:hover button{
-    margin-bottom: 10;
+    filter: opacity(0.95);
+    @apply bg-[#A760FF];
+    margin-bottom: 0;
 }
 
 .menuItemPictureAndPriceGroup {
@@ -38,4 +44,30 @@
 
 .menuItemName::-webkit-scrollbar{
     display: none;
+}
+@keyframes element-pop-in-anim{
+    0%{
+      transform: scale(0);
+    }
+    50%{
+      transform: scale(1.8)
+    }
+    60%{
+      transform: scale(0.6)
+    }
+    80%{
+      transform: scale(1.2)
+    }
+    100%{
+      transform: scale(1)
+    }
+  }
+.elem-bounce{
+    animation: element-pop-in-anim 0.5s cubic-bezier(0.39, 0.575, 0.565, 1);
+}
+.number-indicator{
+    @apply flex absolute top-[10px] outline font-semibold w-[30px] text-center;
+    @apply right-[15px] rounded-[50%] h-[30px] justify-center items-center text-[--foreground] bg-white text-[1rem] z-10;
+    outline-color: rgb(43, 11, 48);
+    outline-width: 2px;
 }

--- a/frontend/src/styles/MenuItem.module.css
+++ b/frontend/src/styles/MenuItem.module.css
@@ -1,13 +1,23 @@
 .menuItem {
-    @apply grid rounded-[6px] flex-col max-w-[160px] h-[200px] p-[20px] bg-[white] gap-[8px] justify-between;
+    @apply grid relative rounded-[6px] flex-col max-w-[160px] h-[200px] p-[20px] bg-[white] overflow-y-clip gap-[8px] justify-between;
     box-shadow: 0 0px 4px 2px var(--drop-shadow-color);
     @apply mobile:max-w-[100%];
 }
-.menuItem button {
-@apply text-[1.2rem] font-semibold rounded-[8px] align-bottom text-[white] bg-[#A760FF] py-[8px] border-none;
+.pos-menu-item{
+    @apply grid relative place-items-center rounded-[6px] flex-col max-w-[160px] h-[200px] p-[20px] bg-[white] overflow-y-clip gap-[4px] justify-between;
+    box-shadow: 0 0px 4px 2px var(--drop-shadow-color);
+    @apply mobile:max-w-[100%];
+    
+}
+.menuItem button, .pos-menu-item button {
+@apply text-[1.2rem] absolute p-[40px] self-end place-self-center mb-[-100px] font-semibold align-bottom text-[white] bg-[#A760FF] py-[8px] border-none;
     &:active {
         @apply bg-[--active-button-color];
     }
+    transition: margin 0.3s ease;
+}
+.menuItem:hover button , .pos-menu-item:hover button{
+    margin-bottom: 10;
 }
 
 .menuItemPictureAndPriceGroup {

--- a/frontend/src/styles/MenuManagementContainer.module.css
+++ b/frontend/src/styles/MenuManagementContainer.module.css
@@ -1,6 +1,12 @@
-.restaurant-current-option-title {
+.restaurant-current-option-title, .restaurant-current-option-title-pos{
     @apply flex gap-[1rem] text-[2rem] my-[10px] pl-[2rem];
     @apply mobile:flex mobile:pl-0 mobile:text-center mobile:justify-center;
+}
+.restaurant-current-option-title-pos{
+  @apply pl-0 mt-[20px] mb-[-40px];
+  > span{
+    @apply font-semibold;
+  }
 }
 .restaurant-current-option-title > span{ @apply font-semibold;}
 .restaurant-components-main-container {@apply flex flex-col items-center;}

--- a/frontend/src/styles/MenuManagementContainer.module.css
+++ b/frontend/src/styles/MenuManagementContainer.module.css
@@ -3,10 +3,10 @@
     @apply mobile:flex mobile:pl-0 mobile:text-center mobile:justify-center;
 }
 .restaurant-current-option-title-pos{
-  @apply pl-0 mt-[20px] mb-[-40px];
-  > span{
+  @apply pl-0 mt-[20px] mb-[-40px];  
+}
+.restaurant-current-option-title-pos > span{
     @apply font-semibold;
-  }
 }
 .restaurant-current-option-title > span{ @apply font-semibold;}
 .restaurant-components-main-container {@apply flex flex-col items-center;}


### PR DESCRIPTION
This update provides some QoL touches to the POS page.

I've gone ahead and added the old styles to the menu items as a temporary solution to make it look more presentable and uniform until the new styles get applied.

New features:

1. The cart is visible from the start.
2. The count icon for the cart now has bouncy animation triggered by adding items.
3.  The menu items now display if these have been added to the cart displaying a small number on the top right corner. The bouncy animation plays out for them when interacted with the count of said item from anywhere.
4. We now have a back to portal button.
5. the items added to the cart have better structure. Before the poor structure and minor styling caused buttons to overlap, making the minus button not react to clicks in most of their visible area.
6. The page now has its name at the top.
7. The menu displays the current selection as its name.
8. The Continue button has been changed to **_Buy_** as previously requested.
9. The buttons now are on screen coordinates / position fixed.
10. The cart component is now on screen coordinates / position fixed.

On a final notes:
Some css files have been modified, but the changes are minimal. Either extra styling has been added or some class names have been changed.