### PR TITLE
Crm 142 fe pos hide UI elements when not needed

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -29,6 +29,7 @@ body {
 .pos-container{
   @apply p-[0] justify-center;
 }
+
 .no-scrollbar::-webkit-scrollbar {
   display: none;
 }

--- a/frontend/src/app/pos/page.tsx
+++ b/frontend/src/app/pos/page.tsx
@@ -99,21 +99,27 @@ export default function POS() {
   return (
     <div className="main-container pos-container">
       <h1 className="text-[2rem] font-semibold my-[2rem]">POS</h1>
-      <Link href="/select-portal">
-        <button className="flex btn fixed right-[100px] top-[20px] bg-transparent hover:bg-[--foreground] hover:border-none
-        w-[fit-content] text-[--foreground] border-[--foreground] hover:text-[white]">
-            {svgIcons.backArrow}
-        </button>
-      </Link>
+      
+      
+        <span className="fixed tooltip tooltip-left right-[120px] transition delay-500
+        top-[44px] bg-[foreground]" data-tip="Go back to Management Center">
+          <Link href="/select-portal">
+            <button className="flex btn fixed right-[70px] top-[20px] bg-white hover:bg-[--foreground] hover:border-[--foreground]
+            w-[fit-content] text-[--foreground] border-[--foreground] hover:text-[white]">
+                {svgIcons.backArrow}
+            </button>            
+          </Link>
+        </span>
+      
       <button
         className={`fixed top-[0px] btn btn-square text-[--foreground] self-end mr-[20px]
-         bg-[--background] hover:bg-[--foreground] hover:text-white border-[--foreground] mt-[20px] `}
+         bg-[--background] hover:border-[--foreground] hover:bg-[--foreground] hover:text-white border-[--foreground] mt-[20px] `}
         onClick={() => setIsCartVisible((prevVisibility) => !prevVisibility)}
         aria-label="Cart toggle button"
       >
         {svgIcons.cart}
         { amountOfItemsInCart > 0 && <span key={amountOfItemsInCart} className={`flex justify-center absolute w-[30px] text-[--foreground]
-        h-[30px] bottom-[-20px] left-[-18px] bg-white outline rounded-[50%] ${menuItemStyles["elem-bounce"]}`}>
+        h-[30px] top-[-15px] right-[-10px] bg-white outline rounded-[50%] ${menuItemStyles["elem-bounce"]}`}>
             <span  className={`self-center text-[--custom-active-red-color] pointer-events-none`}>{amountOfItemsInCart}</span>
           </span>}
       </button>
@@ -135,10 +141,9 @@ export default function POS() {
             <span>{currentSelection === "none" ? "All" : currentSelection}</span> Menu
       </span>
 
-      <span className="flex gap-[2rem] w-full justify-center place-items-center ml-[-20px] p-[20px] mt-[20px]">
+      <span className="flex gap-[2rem] w-full justify-center place-items-center p-[20px] mt-[20px]">
         <span
-          className="grid grid-flow-row-dense tablet:grid-cols-2 mobile:grid-cols-1 
-          p-[20px] grid-cols-4 gap-[20px] max-h-[600px] overflow-y-auto"
+          className={styles["menu-items-container-pos"]}
         >
           {filteredMenuItems?.map((item, index) => {
             const imgSize = 80;

--- a/frontend/src/app/pos/page.tsx
+++ b/frontend/src/app/pos/page.tsx
@@ -78,7 +78,24 @@ export default function POS() {
   const findElement =(item: MenuItemType)=>{
     return addedItems.find(searchedItem => searchedItem.foodName === item.name)
   }
-  console.table(menuItems);
+  const addItemToCart =(item: MenuItemType)=>{
+    const newItem: ItemProps = {
+      foodName: item.name,
+      foodPrice: parseFloat(item.price),
+      quantity: 1,
+    };
+    const allItems = [...addedItems];
+    const itemFoundIndex = allItems.findIndex(
+      (item) => item.foodName === newItem.foodName
+    );
+    if (itemFoundIndex >= 0 && itemFoundIndex < allItems.length 
+      && allItems[itemFoundIndex]?.quantity !== undefined) {
+      allItems[itemFoundIndex].quantity += 1;
+      setAddedItems([...allItems]);
+    } else {
+      setAddedItems((prevItems) => [...prevItems, newItem]);
+    }
+  }
   return (
     <div className="main-container pos-container">
       <h1 className="text-[2rem] font-semibold my-[2rem]">POS</h1>
@@ -95,7 +112,7 @@ export default function POS() {
         aria-label="Cart toggle button"
       >
         {svgIcons.cart}
-        { addedItems.length > 0 && <span key={amountOfItemsInCart} className={`flex justify-center absolute w-[30px] text-[--foreground]
+        { amountOfItemsInCart > 0 && <span key={amountOfItemsInCart} className={`flex justify-center absolute w-[30px] text-[--foreground]
         h-[30px] bottom-[-20px] left-[-18px] bg-white outline rounded-[50%] ${menuItemStyles["elem-bounce"]}`}>
             <span  className={`self-center text-[--custom-active-red-color] pointer-events-none`}>{amountOfItemsInCart}</span>
           </span>}
@@ -144,24 +161,7 @@ export default function POS() {
                 </span>
                 <button
                   className="btn tablet:text-[0.7rem] rounded-none h-full"
-                  onClick={() => {
-                    const newItem: ItemProps = {
-                      foodName: item.name,
-                      foodPrice: parseFloat(item.price),
-                      quantity: 1,
-                    };
-                    const allItems = [...addedItems];
-                    const itemFoundIndex = allItems.findIndex(
-                      (item) => item.foodName === newItem.foodName
-                    );
-                    if (itemFoundIndex >= 0 && itemFoundIndex < allItems.length 
-                      && allItems[itemFoundIndex]?.quantity !== undefined) {
-                      allItems[itemFoundIndex].quantity += 1;
-                      setAddedItems([...allItems]);
-                    } else {
-                      setAddedItems((prevItems) => [...prevItems, newItem]);
-                    }
-                  }}
+                  onClick={()=> addItemToCart(item)}
                 >
                   Add Item
                 </button>

--- a/frontend/src/components/POS/Cart.tsx
+++ b/frontend/src/components/POS/Cart.tsx
@@ -43,7 +43,7 @@ export default function Cart(orderInfo: CartInfo) {
   return (
     <div className={styles["cart-container"]}>
       <span className={styles["cart-title"]}>Cart</span>
-      <span className="flex flex-col h-[400px] gap-[10px] overflow-y-auto">
+      <span className="flex flex-col h-[400px] gap-[10px] overflow-y-auto outline p-[5px] rounded-[8px]">
         {
             orderInfo.items?.map((item, index)=>{
                 const currItem: ItemProps={

--- a/frontend/src/components/POS/Cart.tsx
+++ b/frontend/src/components/POS/Cart.tsx
@@ -39,6 +39,7 @@ export interface ItemProps{
 }
 export default function Cart(orderInfo: CartInfo) {
   const cartTotalCost = orderInfo.items.reduce((prevVal, currVal)=> prevVal + (currVal.quantity? (currVal.foodPrice * currVal.quantity): currVal.foodPrice), 0).toFixed(2)
+  const itemsAvailable = orderInfo.items.length;
   return (
     <div className={styles["cart-container"]}>
       <span className={styles["cart-title"]}>Cart</span>
@@ -62,10 +63,10 @@ export default function Cart(orderInfo: CartInfo) {
             <span>Total</span>
             <span>${cartTotalCost}</span>
         </span>
-        <span className="grid grid-rows-2 w-full gap-[1rem]">
+        {itemsAvailable > 0 && <span className="grid grid-rows-2 w-full gap-[1rem]">
             <button className="btn bg-[--continue-button-color] border-none hover:bg-purple-500 active:bg-[--foreground-2] text-white">Buy</button>
             <button className="btn btn-error text-white" onClick={()=>orderInfo.cancelOrder()}>Cancel</button>
-        </span>
+        </span>}
       </span>
     </div>
   );
@@ -81,8 +82,8 @@ const ItemComponent=(itemInfo: ItemProps)=>{
                 <span className="flex items-center">
                   <span className="pr-[10px]">{itemInfo.quantity}</span>
                   <span className="flex relative gap-[4px]">
+                    {(itemInfo.quantity ?? 0) > 1 && <button className="btn btn-outline btn-secondary" onClick={()=>itemInfo.actions?.decreaseQty(itemInfo.foodName)}>-</button>}
                     <button className="btn btn-outline btn-primary"   onClick={()=>itemInfo.actions?.increaseQty(itemInfo.foodName)}>+</button>
-                    <button className="btn btn-outline btn-secondary" onClick={()=>itemInfo.actions?.decreaseQty(itemInfo.foodName)}>-</button>
                   </span>
                 </span>
             </span>

--- a/frontend/src/styles/Cart.module.css
+++ b/frontend/src/styles/Cart.module.css
@@ -1,9 +1,8 @@
 .cart-container{
     @apply flex fixed right-[10px] flex-col px-[40px] gap-[1rem];
     @apply py-[20px] rounded-[8px] max-w-[500px] min-w-[300px] bg-white h-[80%] outline;
-    @apply justify-evenly top-[100px];
-    z-index: 10;
-    
+    @apply justify-evenly top-[100px] mobile:min-w-full mobile:right-0 mobile:rounded-none tablet:bottom-[10px] tablet:top-[unset];
+    z-index: 10;    
 }
 .pos-item-name{
     @apply text-lg max-w-[200px];

--- a/frontend/src/styles/MenuManagementContainer.module.css
+++ b/frontend/src/styles/MenuManagementContainer.module.css
@@ -33,3 +33,9 @@
     @apply mobile:grid-cols-1 mobile-m:grid-cols-2 mobile:w-[90dvw] tablet:grid-cols-3;
     place-items: center; 
   }
+
+  .menu-items-container-pos{
+    @apply grid grid-flow-row-dense tablet:grid-cols-2 mobile:grid-cols-1;
+    @apply p-[20px] grid-cols-4 gap-[20px] max-h-[600px] overflow-y-auto;
+    @apply tablet:grid-cols-2 tablet:self-baseline;
+  }


### PR DESCRIPTION
This update introduces qol changes, and some new features:

1. The two top right buttons have been re-arranged to look more organized.
![image](https://github.com/user-attachments/assets/335d5782-5060-4e8c-b641-09e0b34a4d6e)

2. The cart button's counter now appears at the top right to help keep the button to its left closer together.
3. A tool tip has been introduced for the go back to the management center button.
![image](https://github.com/user-attachments/assets/a7ef4a48-db38-45f5-b243-35deac33e376)
4. Everything else added here has been responsiveness for the cart element for both tablet and mobile.
5. The cart component now doesn't display buttons if no items are in it.
![image](https://github.com/user-attachments/assets/3113dea9-49a8-4067-bfbd-2dec4d554564)
6. The cart now has an outline where elements are supposed to go.

PS:
The Cart component is supposed to be on top of the other elements when visible on smaller screens. Clicking on the cart button disables it if there's a need to operate the item menu.