### PR TITLE
CRM-144-fe-order-tracking-make-current-orders-visible-when-first-visiting-the-page

### DIFF
--- a/frontend/src/app/orderTracking/page.tsx
+++ b/frontend/src/app/orderTracking/page.tsx
@@ -9,7 +9,7 @@ import OrderDetailsScreen, { OrderDetails } from "@/components/OrderDetailsScree
 import TimeDropdown, { TimeDropdownProps } from "@/components/TimeDropdown";
 
 export default function OrderTrackingPage() {
-  const { currentSelection, isCurrentSelection, setCurrentSelection } = useSelection()
+  const { currentSelection, isCurrentSelection, setCurrentSelection } = useSelection("Current Orders")
   
   let fetchString = "orders?"
   if(!isCurrentSelection("none")){

--- a/frontend/src/customHooks/useSelection.tsx
+++ b/frontend/src/customHooks/useSelection.tsx
@@ -1,8 +1,8 @@
 'use client'
 import {useState} from 'react'
 
-export default function useSelection() {
-    const [currentSelection, setCurrentSelection] = useState("none")
+export default function useSelection(selection: string = "none") {
+    const [currentSelection, setCurrentSelection] = useState(selection)
     const isCurrentSelection = (passedValue: string)=>{
         return currentSelection.toLowerCase() === passedValue.toLowerCase().trimStart() 
     }


### PR DESCRIPTION
Current orders is now instantly displayed when the order tracking page is visited.