### PR TITLE
Crm 169 fe current orders display quantity single item

### DIFF
--- a/frontend/src/app/pos/page.tsx
+++ b/frontend/src/app/pos/page.tsx
@@ -108,17 +108,15 @@ export default function POS() {
   return (
     <div className="main-container pos-container">
       <h1 className="text-[2rem] font-semibold my-[2rem]">POS</h1>
-      
-      
-        <span className="fixed tooltip tooltip-left right-[120px] transition delay-500
-        top-[44px] bg-[foreground]" data-tip="Go back to Management Center">
-          <Link href="/select-portal">
-            <button className="flex btn fixed right-[70px] top-[20px] bg-white hover:bg-[--foreground] hover:border-[--foreground]
-            w-[fit-content] text-[--foreground] border-[--foreground] hover:text-[white]">
-                {svgIcons.backArrow}
-            </button>            
-          </Link>
-        </span>
+      <span className="fixed tooltip tooltip-left right-[120px] transition delay-500
+      top-[44px] bg-[foreground]" data-tip="Go back to Management Center">
+        <Link href="/select-portal">
+          <button className="flex btn fixed right-[70px] top-[20px] bg-white hover:bg-[--foreground] hover:border-[--foreground]
+          w-[fit-content] text-[--foreground] border-[--foreground] hover:text-[white]">
+              {svgIcons.backArrow}
+          </button>            
+        </Link>
+      </span>
       
       <button
         className={`fixed top-[0px] btn btn-square text-[--foreground] self-end mr-[20px]
@@ -192,11 +190,6 @@ export default function POS() {
         </span>
         {isCartVisible && <Cart {...cartInfo} />}
       </span>
-      
-      
-      
-      
-      
     </div>
   );
 }

--- a/frontend/src/components/InteractableOrderItem.tsx
+++ b/frontend/src/components/InteractableOrderItem.tsx
@@ -8,11 +8,11 @@ export default function InteractableOrderItem(itemDetails: ItemDetails) {
   return (
     <div className={styles["interactable-order-item"]}>
       <span className={styles["order-item-top-group"]}>
-        <span className={styles["order-item-name"]}>{itemDetails.name}</span>
+        <p className={styles["order-item-name"]}>{itemDetails.name}</p>
       </span>
       <span className={styles["remove-and-price-group"]}>
-        <span className={styles["order-item-price"]}>${(itemDetails.price * itemDetails.quantity).toFixed(2)}</span>        
-        {itemDetails.quantity && <span>Qty {itemDetails.quantity}</span>}        
+        <p className={styles["order-item-price"]}>${(itemDetails.price * itemDetails.quantity).toFixed(2)}</p>        
+        {itemDetails.quantity && <p>Qty {itemDetails.quantity}</p>}        
       </span>
     </div>
   );

--- a/frontend/src/components/InteractableOrderItem.tsx
+++ b/frontend/src/components/InteractableOrderItem.tsx
@@ -11,8 +11,8 @@ export default function InteractableOrderItem(itemDetails: ItemDetails) {
         <span className={styles["order-item-name"]}>{itemDetails.name}</span>
       </span>
       <span className={styles["remove-and-price-group"]}>
-        <span className={styles["order-item-price"]}>${itemDetails.price}</span>        
-        {itemDetails.quantity && <span>{itemDetails.quantity}</span>}        
+        <span className={styles["order-item-price"]}>${(itemDetails.price * itemDetails.quantity).toFixed(2)}</span>        
+        {itemDetails.quantity && <span>Qty {itemDetails.quantity}</span>}        
       </span>
     </div>
   );

--- a/frontend/src/components/OrderReceiptManager.tsx
+++ b/frontend/src/components/OrderReceiptManager.tsx
@@ -66,6 +66,22 @@ export default function OrderReceiptManager(orderDetails: Order) {
     return ""
   }
   const timeStamp = orderDetails.ordertimestamp ? new Date(orderDetails.ordertimestamp) : "";
+  const finalOrderItems: ItemDetails[] = [];
+  if(orderDetails.orderitems.length){
+    orderDetails.orderitems.forEach((item: OrderItem) => {
+      const itemIndex = finalOrderItems.findIndex((orderItem) => orderItem.name === item.menuitems.name);
+      if(itemIndex >= 0){
+        finalOrderItems[itemIndex].quantity += 1;
+      }
+      else{
+        finalOrderItems.push({
+          name: item.menuitems.name,
+          price: item.menuitems.price,
+          quantity: 1
+        });
+      }
+    });
+  }
   return (
     <>
       {!orderStatus && <div className={`${styles["current-order-items-manager"]} carousel-item`}>
@@ -81,15 +97,9 @@ export default function OrderReceiptManager(orderDetails: Order) {
         </div>
 
         <div className={styles["order-items-container"]}>
-          {
-            orderDetails.orderitems && orderDetails.orderitems.map((details, index) => {
-              const itemDetails: ItemDetails = {
-                name: details.menuitems.name,
-                price: details.menuitems.price,
-                quantity: details.menuitems.quantity,
-              }
-              console.log(`details.menuitems.quantity ${details.menuitems.quantity}`)
-              return <InteractableOrderItem key={index} {...itemDetails} />
+          {            
+            finalOrderItems && finalOrderItems.map((details, index) => {
+              return <InteractableOrderItem key={index} {...details} />
             })
           }
         </div>


### PR DESCRIPTION
This update introduces some qol visual changes for the current orders tab.

1. Current orders now instantly disappear whenever you click on the toggle order status button.
2. Current orders now display a single order instead of multiples of the same. These single orders stack, and display their total price based on the quantity, and the quantity.
3. Orders now use the forever lovely p tags wherever data is displayed that's not a title.

