### PR TITLE
CRM-177 FE - Some order data is still appearing blue on the Completed Orders screen

### DIFF
--- a/frontend/src/styles/TimeDropdown.module.css
+++ b/frontend/src/styles/TimeDropdown.module.css
@@ -28,7 +28,7 @@
 }
 
 .table-body {
-  @apply block h-[20rem] text-black overflow-y-auto;
+  @apply block h-[20rem]  overflow-y-auto;
 }
 
 .hide-data {
@@ -38,7 +38,7 @@
 .table-row-format {
   @apply grid grid-flow-col grid-cols-[1fr_10px_1fr_10px_1fr_10px_1fr_10px_1fr] auto-cols-fr;
   @apply border border-b-[1px] border-[var(--foreground)];
-  @apply justify-items-center text-center h-[58px] items-center;
+  @apply justify-items-center text-center text-black h-[58px] items-center;
   @apply mobile:items-center;
 }
 


### PR DESCRIPTION
This was a simple fix, I moved the text-black property from applying to the table body to apply to each row instead. The reason the bug was happening is that the CSS on the table body only applies if there are more than 5 orders for that timespan. Because of this, it wasn't initially showing in black. Now all row text will show in black.