### PR TITLE
CRM-179 FE Remove backticks from DineFlow description on the splash page

### DIFF
--- a/frontend/src/components/SplashScreen.tsx
+++ b/frontend/src/components/SplashScreen.tsx
@@ -123,7 +123,7 @@ const SplashScreen: React.FC = () => {
         <div className="max-w-5xl mx-auto text-center">
           <h2 id="cta-heading" className="text-4xl font-bold mb-6 text-gray-800">Experience a better way to work with Dine Flow</h2>
           <p className="text-xl mb-10 max-w-3xl mx-auto text-gray-600">
-            Take your restaurant to new heights of collaboration, connection, and efficiency with Dine Flow`&apos;`s integrated platform — available now.
+            Take your restaurant to new heights of collaboration, connection, and efficiency with Dine Flow's integrated platform — available now.
           </p>
         </div>
       </section>

--- a/frontend/src/components/SplashScreen.tsx
+++ b/frontend/src/components/SplashScreen.tsx
@@ -123,7 +123,7 @@ const SplashScreen: React.FC = () => {
         <div className="max-w-5xl mx-auto text-center">
           <h2 id="cta-heading" className="text-4xl font-bold mb-6 text-gray-800">Experience a better way to work with Dine Flow</h2>
           <p className="text-xl mb-10 max-w-3xl mx-auto text-gray-600">
-            Take your restaurant to new heights of collaboration, connection, and efficiency with Dine Flow's integrated platform — available now.
+            Take your restaurant to new heights of collaboration, connection, and efficiency with Dine Flow{`${"'"}`}s integrated platform — available now.
           </p>
         </div>
       </section>


### PR DESCRIPTION
On the splash screen, "Dine Flow's" was being shown with backticks around the apostrophe. this PR removes those backticks and now it only shows the apostrophe.