### PR TITLE
CRM-181 FE remove the "r" on phase in the New Updates section of the Hub page

### DIFF
--- a/frontend/src/components/HomePage.tsx
+++ b/frontend/src/components/HomePage.tsx
@@ -171,7 +171,7 @@ const RestaurantDashboard: React.FC = () => {
               <h3 className="text-lg font-bold">New Updates</h3>
             </div>
             <p className="text-center">
-              Get ready for the next phaser of Dine Flow with online ordering dashboards.
+              Get ready for the next phase of Dine Flow with online ordering dashboards.
             </p>
           </div>
 


### PR DESCRIPTION
The letter R just needed to be removed from the word phase in New Updates.