### PR TITLE
Crm 174 fe fix menu manager mobile link current orders to pos

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -3,8 +3,10 @@
 @tailwind utilities;
 
 :root {
-  --background: #fafbff;
-  --foreground: #638de5;
+  --original-background: #fafbff;
+  --background: var(--original-background);
+  --original-foreground: #638de5;
+  --foreground: var(--original-foreground);
   --foreground-2: #747dbe;
   --active-button-color: #6063ff;
   --remove-button-bg-color: #a760ff;
@@ -15,10 +17,15 @@
   --rows-drop-shadow: 0 2px 2px 1px var(--drop-shadow-color);
   --sellers-container-drop-shadow: 0 1px 4px 1px var(--drop-shadow-color);
   --top-most-z-index: 1000;
+  --color: white;
+  --brand-blue: #001F3F;
+  --brand-pink: #FFE8F0;
+  --brand-orange: #FF8532;
+  --brand-white: #ffffff;
   background-color: var(--background);  
 }
 
-body {
+body {  
   color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
   user-select: none;

--- a/frontend/src/app/orderTracking/page.tsx
+++ b/frontend/src/app/orderTracking/page.tsx
@@ -17,8 +17,6 @@ export default function OrderTrackingPage() {
     fetchString = `orders?completed=${showCompletedOrders}&orderItemsDetails=true`
   }
   const { data } = useFetch<{ orders: Order[] }>(fetchString);
-  const [orders, setOrders] = useState<Order[] | undefined>(data?.orders)
-  const [containerKey, setContainerKey] = useState<string>("20")
   console.log(data)
   const selObject: SelectionObject = {
     setCurrentSelection: setCurrentSelection,
@@ -36,22 +34,19 @@ export default function OrderTrackingPage() {
     orders: data?.orders,
     setOrderDetails: setCurrentOrderDetails
   }
-  const orderChecker =()=>{
-    if(data?.orders === undefined || data.orders.length <= 0){
-      return (<div>No Orders Found</div>)
-    }
-    return data?.orders.map((order)=> <OrderReceiptManager key={order.orderid} {...order} />)
-  }
 
   return (
     <div className="main-container">
       <h1 className="text-3xl font-bold text-center my-[0.5rem]">Order Tracking</h1>
       <OrderTrackingMenu {...selObject} />
       <div className={orderTrackingStyles["order-tracking-container"]}>
-        { (isCurrentSelection("Current Orders") && orders) && <div className={orderTrackingStyles["order-receipt-container"]}>
-            {orderChecker()}
-        </div>}     
-        {/* {(isCurrentSelection("Current Orders") && (orders?.length === undefined || orders?.length <= 0)) && <div>No Orders Found</div>}   */}
+      {(isCurrentSelection("Current Orders") && data) && <div className={orderTrackingStyles["order-receipt-container"]}>
+        {data?.orders.map((order, index)=>{
+          order.animIndex = index;
+          order.animDelay = index * 0.02;
+          return <OrderReceiptManager key={order.orderid} {...order} />})
+        }
+        </div>}      
         {isCurrentSelection("Completed Orders") && <TimeDropdown {...completedOrders} />}
       </div>      
       {currentOrderDetails && <OrderDetailsScreen {...orderDetailsObj} />}

--- a/frontend/src/app/orderTracking/page.tsx
+++ b/frontend/src/app/orderTracking/page.tsx
@@ -7,9 +7,9 @@ import OrderReceiptManager, { Order } from "@/components/OrderReceiptManager";
 import { SelectionObject } from "@/components/SelectionObject";
 import OrderDetailsScreen, { OrderDetails } from "@/components/OrderDetailsScreen";
 import TimeDropdown, { TimeDropdownProps } from "@/components/TimeDropdown";
-
+import orderTrackingStyles from "../../styles/OrderTracking.module.css";
 export default function OrderTrackingPage() {
-  const { currentSelection, isCurrentSelection, setCurrentSelection } = useSelection("Current Orders")
+  const {isCurrentSelection, setCurrentSelection } = useSelection("Current Orders")
   
   let fetchString = "orders?"
   if(!isCurrentSelection("none")){
@@ -17,6 +17,8 @@ export default function OrderTrackingPage() {
     fetchString = `orders?completed=${showCompletedOrders}&orderItemsDetails=true`
   }
   const { data } = useFetch<{ orders: Order[] }>(fetchString);
+  const [orders, setOrders] = useState<Order[] | undefined>(data?.orders)
+  const [containerKey, setContainerKey] = useState<string>("20")
   console.log(data)
   const selObject: SelectionObject = {
     setCurrentSelection: setCurrentSelection,
@@ -30,32 +32,28 @@ export default function OrderTrackingPage() {
     order: currentOrderDetails,
     updateOrderDetailsScreen: updateOrderDetails
   }
-
   const completedOrders: TimeDropdownProps = {
     orders: data?.orders,
     setOrderDetails: setCurrentOrderDetails
+  }
+  const orderChecker =()=>{
+    if(data?.orders === undefined || data.orders.length <= 0){
+      return (<div>No Orders Found</div>)
+    }
+    return data?.orders.map((order)=> <OrderReceiptManager key={order.orderid} {...order} />)
   }
 
   return (
     <div className="main-container">
       <h1 className="text-3xl font-bold text-center my-[0.5rem]">Order Tracking</h1>
       <OrderTrackingMenu {...selObject} />
-      {(data?.orders.length !== undefined && data?.orders.length > 0) && <div className={`flex order-tracking-main-container max-w-[80dvw] justify-center mt-[20px]
-        mobile:max-w-full mobile:mb-[4rem]
-        `} >
-          {isCurrentSelection("Current Orders") && <div key={currentSelection}
-          className={`carousel max-h-[max-content] justify-start align-center overflow-x-auto p-[2rem] rounded-box bg-neutral
-           gap-[1rem] carousel-start w-full scroll-smooth outline mobile:w-full mobile:carousel-vertical
-           mobile:rounded-none mobile:items-center mobile:p-[2rem] tablet:pt-[10px] tablet:mb-[4rem]`}>
-            {
-              (data?.orders && data.orders.length) &&
-                data?.orders.map((order)=>{
-                  return <OrderReceiptManager key={order.orderid} {...order} />
-                })
-            }
-        </div>} 
-        {data && isCurrentSelection("Completed Orders") && <TimeDropdown {...completedOrders} />}
-      </div>}
+      <div className={orderTrackingStyles["order-tracking-container"]}>
+        { (isCurrentSelection("Current Orders") && orders) && <div className={orderTrackingStyles["order-receipt-container"]}>
+            {orderChecker()}
+        </div>}     
+        {/* {(isCurrentSelection("Current Orders") && (orders?.length === undefined || orders?.length <= 0)) && <div>No Orders Found</div>}   */}
+        {isCurrentSelection("Completed Orders") && <TimeDropdown {...completedOrders} />}
+      </div>      
       {currentOrderDetails && <OrderDetailsScreen {...orderDetailsObj} />}
     </div>
   );

--- a/frontend/src/app/pos/page.tsx
+++ b/frontend/src/app/pos/page.tsx
@@ -188,13 +188,13 @@ export default function POS() {
       </span>      
       <button
         className={`fixed top-[0px] btn btn-square text-[--foreground] self-end mr-[20px] z-[--top-most-z-index]
-         bg-[--background] hover:border-[--foreground] hover:bg-[--foreground] hover:text-white border-[--foreground] mt-[20px] `}
+         bg-[--brand-white] hover:border-[--foreground] hover:bg-[--foreground] hover:text-white border-[--foreground] mt-[20px] `}
         onClick={() => setIsCartVisible((prevVisibility) => !prevVisibility)}
         aria-label="Cart toggle button"
       >
         {svgIcons.cart}
         { amountOfItemsInCart > 0 && <span key={amountOfItemsInCart} className={`flex justify-center absolute w-[30px] text-[--foreground]
-        h-[30px] top-[-15px] right-[-10px] bg-white outline rounded-[50%] ${menuItemStyles["elem-bounce"]}`}>
+        h-[30px] top-[-15px] right-[-10px] bg-[--color] outline rounded-[50%] ${menuItemStyles["elem-bounce"]}`}>
             <span  className={`self-center text-[--custom-active-red-color] pointer-events-none`}>{amountOfItemsInCart}</span>
           </span>}
       </button>

--- a/frontend/src/app/pos/page.tsx
+++ b/frontend/src/app/pos/page.tsx
@@ -141,6 +141,7 @@ export default function POS() {
               <span
                 className={menuItemStyles["pos-menu-item"]}
                 key={index}
+                style={{"--transition-delay": `${index * 0.08}s`} as React.CSSProperties}
               >
                 <Image
                   src={item.pictureUrl}

--- a/frontend/src/app/pos/page.tsx
+++ b/frontend/src/app/pos/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 import Cart, { CartInfo, ItemProps } from "@/components/POS/Cart";
 import { useFetch } from "@/customHooks/useFetch";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import useSelection from "@/customHooks/useSelection";
 import type { MenuItemType } from "@/components/MenuManagementContainer";
 import SelectableButton from "@/components/SelectableButton";
@@ -105,14 +105,17 @@ export default function POS() {
       setAddedItems((prevItems) => [...prevItems, newItem]);
     }
   }
+
+  useEffect(()=>{ 
+    if(typeof window !== undefined){
+      const isMobile = window.innerWidth <= 500;
+      setIsCartVisible(!isMobile);
+    }
+  },[])
+
   
   return (
-    <div className="main-container pos-container" onLoad={()=>{
-      if(typeof window !== undefined){
-        const isMobile = window.innerWidth <= 500;
-        setIsCartVisible(!isMobile);
-      }
-    }}>
+    <div className="main-container pos-container">
       <h1 className="text-[2rem] font-semibold my-[2rem]">POS</h1>
       <div className={styles["restaurant-sub-menu-container"]}>
         {menuCategories.map((menuItem, index) => {

--- a/frontend/src/components/MenuItem.tsx
+++ b/frontend/src/components/MenuItem.tsx
@@ -25,11 +25,11 @@ export default function MenuItem(itemInfo: MenuItemProps) {
           {itemInfo.picture && itemInfo.name && <Image src={itemInfo.picture} width={imageSize} height={imageSize} alt={itemInfo.name}/>}
         </span>
         <span className={styles.menuPricingGroup}>
-          <span>Price:</span>
-          <span className="menu-item-price">${itemInfo.price}</span>
+          <p>Price:</p>
+          <p className="menu-item-price">${itemInfo.price}</p>
         </span>
       </span>
-      <span className={styles.menuItemName}>{itemInfo.name}</span>
+      <p className={styles.menuItemName}>{itemInfo.name}</p>
     </div>
   );
 }

--- a/frontend/src/components/MenuManagementContainer.tsx
+++ b/frontend/src/components/MenuManagementContainer.tsx
@@ -69,7 +69,7 @@ export default function MenuManagementContainer({ menuItems }: MenuManagementCon
     id: itemSelected?.id
   }
   return (
-    <div className={`${styles["restaurant-main-food-menu-container"]} overflow-y-hidden flex-1`}>
+    <div className={`${styles["restaurant-parent-container"]} `}>
       <div className={styles["restaurant-sub-menu-container"]}>
         {menuCategories.map((menuItem, index) => {
           return (

--- a/frontend/src/components/OrderDetailsScreen.tsx
+++ b/frontend/src/components/OrderDetailsScreen.tsx
@@ -8,71 +8,77 @@ export interface OrderDetails{
 }
 
 export default function OrderDetailsScreen(orderDetails: OrderDetails) {
-  const oDetails = orderDetails.order
+  const oDetails = orderDetails.order  
   const disableModal =()=>{
     orderDetails.updateOrderDetailsScreen(null)
   }
+  const orderTotal = oDetails?.orderitems.reduce((acc, curr)=>{ return acc + parseFloat(curr.menuitems.price.toString())},0)
+  const tax = parseFloat(((Math.random() * 10) + 1).toFixed(2));
+  const finalPrice = orderTotal? (tax + orderTotal).toFixed(2): 0;
   return (
-    <dialog className={styles["order-details-container"]} 
-    onLoadStart={(e)=> e.currentTarget.focus()}
-    onKeyDown={(e)=> {
-      if(e.key ===  'Escape') disableModal()
-     }}
-    >
+    <>
       <span className={styles["order-details-container-bg"]} onClick={disableModal}></span>
-      <h1 className={styles["order-details-title"]}>Order Details</h1>
-      <button className={styles["exit-button"]}
-       onClick={disableModal}
-       >Exit</button>
-      <span className="flex gap-[1rem] mt-[40px] justify-center">        
-        <span className={styles["full-order-details-container"]}>
-          <span className={styles["order-details-header"]}>
-            <span>Restaurant Name</span>
-            <span>Order #{oDetails?.orderid}</span>
-            <span>Order Date</span>
+      <dialog className={styles["order-details-container"]} 
+      onLoadStart={(e)=> e.currentTarget.focus()}
+      onKeyDown={(e)=> {
+        if(e.key ===  'Escape') disableModal()
+      }}
+      >      
+        <h1 className={styles["order-details-title"]}>Order Details</h1>
+        <button className={styles["exit-button"]}
+        onClick={disableModal}
+        >Exit</button>
+        <span className="flex gap-[1rem] mt-[40px] justify-center">        
+          <span className={styles["full-order-details-container"]}>
+            <span className={styles["order-details-header"]}>
+              <p>Restaurant Name</p>
+              <p>Order #{oDetails?.orderid}</p>
+              <p>Order Date</p>
+            </span>
+            <span className={styles["items-list-container"]}>
+              {oDetails?.orderitems && oDetails?.orderitems.map((elem, index)=>{
+                  return(
+                      <ul key={index}>
+                          <li>Order Name {elem.menuitems.name}</li>
+                          <li>${elem.menuitems.price}</li>
+                      </ul>
+                  )
+              })}
+            </span>
+            <span className={styles["purchase-cost-details"]}>
+              <p>Subtotal: ............${orderTotal? orderTotal.toFixed(2): 0}</p>
+              <p>Tax: ............${tax}</p>
+              <p>Total: ............${finalPrice}</p>
+            </span>
+            <span className={styles["message-and-payment-method-container"]}>
+              <p>Payment Method:</p>
+              <p>Credit Card(**** 2394)</p>
+              <p>{`Thank you for choosing Cluckin' Good Chicken! Have a cluckin' great day! 🐔`}</p>
+            </span>
           </span>
-          <span className={styles["items-list-container"]}>
-            {oDetails?.orderitems && oDetails?.orderitems.map((elem, index)=>{
-                return(
-                    <ul key={index}>
-                        <li>Order Name {elem.menuitems.name}</li>
-                        <li>${elem.menuitems.price}</li>
-                    </ul>
-                )
-            })}
-          </span>
-          <span className={styles["purchase-cost-details"]}>
-            <span>Subtotal: ............$20.00</span>
-            <span>Tax: ............$6.00</span>
-            <span>Total: ............$26.00</span>
-          </span>
-          <span className={styles["message-and-payment-method-container"]}>
-            <span>Payment Method:</span>
-            <span>Credit Card(**** 2394)</span>
-            <span>{`Thank you for choosing Cluckin' Good Chicken! Have a cluckin' great day! 🐔`}</span>
-          </span>
-        </span>
-        <span className={styles["modify-order-container"]}>
-          <h2 className={styles["modify-order-button"]}>Modify Order</h2>
-          <span className={styles["current-state-container"]}>
-            <span>Current State: </span>
-            <button className="btn bg-[--foreground] border-none text-white">
-              Mark As In Progress
+          <span className={styles["modify-order-container"]}>
+            <h2 className={styles["modify-order-button"]}>Modify Order</h2>
+            <span className={styles["current-state-container"]}>
+              <span>Current State: {orderDetails.order?.completed? "Completed": "In Progress"}</span>
+              <button className="btn bg-[--foreground] border-none text-white">
+                Mark As In Progress
+              </button>
+            </span>
+            <span className={styles["current-state-container"]}>
+              <span>Current State: </span>
+              <button className="btn bg-[--foreground] border-none text-white">
+                Mark Refunded / Dissatisfied
+              </button>
+            </span>
+            <button className="btn w-[max-content] bg-[--foreground] border-none text-white"
+              onClick={()=> window.print()}
+            >
+              Print Receipt
             </button>
           </span>
-          <span className={styles["current-state-container"]}>
-            <span>Current State: </span>
-            <button className="btn bg-[--foreground] border-none text-white">
-              Mark Refunded / Dissatisfied
-            </button>
-          </span>
-          <button className="btn w-[max-content] bg-[--foreground] border-none text-white"
-            onClick={()=> window.print()}
-          >
-            Print Receipt
-          </button>
         </span>
-      </span>
-    </dialog>
+      </dialog>
+    </>
+    
   );
 }

--- a/frontend/src/components/OrderReceiptManager.tsx
+++ b/frontend/src/components/OrderReceiptManager.tsx
@@ -1,6 +1,6 @@
 "use client";
 import InteractableOrderItem, { ItemDetails } from "./InteractableOrderItem";
-import {useState} from "react";
+import React,{useState} from "react";
 import { useMutation } from "@/customHooks/useMutation";
 import OrderStatusNotifier from "./OrderStatusNotifier";
 import styles from "../styles/OrderReceiptManager.module.css"
@@ -13,6 +13,8 @@ export type Order = {
   ordertimestamp: string;
   completedTimeStamp: string | null;
   toggleOrderDetails?: ()=> void;
+  animDelay: number;
+  animIndex: number;
 };
 export type AddedItem = {
   price: number;
@@ -84,7 +86,7 @@ export default function OrderReceiptManager(orderDetails: Order) {
   }
   return (
     <>
-      {!orderStatus && <div className={`${styles["current-order-items-manager"]} carousel-item`}>
+      {!orderStatus && <div className={`${styles["current-order-items-manager"]} carousel-item`} style={{"--trans-delay": `${orderDetails.animIndex * orderDetails.animDelay}s`} as React.CSSProperties}>
         <button className={`${styles["order-status-toggle-button"]}`} onClick={() => toggleOrderStatus()}>Toggle Order Status</button>
         <span className={`${styles["order-status"]}`}>{orderStatus ? "Completed" : "In Progress"}</span>
         <span className={`${styles["order-details-container-bg"]} `}></span>

--- a/frontend/src/components/SideNavBar.tsx
+++ b/frontend/src/components/SideNavBar.tsx
@@ -20,7 +20,6 @@ export default function SideNavBar() {
     }    
   }
   const pageNow = usePathname()
-  console.log(pageNow)
   const canDisplay =()=>{
     switch(pageNow){
       case "/pos": return false; break;
@@ -33,8 +32,7 @@ export default function SideNavBar() {
   const buttonIcons = [svgIcons.home, svgIcons.menuManager, svgIcons.orderTracking,
     svgIcons.inventory, svgIcons.productivity, svgIcons.settings]
   const buttonStyle = styles["side-nav-bar-button"]
-  return (
-    
+  return (    
       <>
         { canDisplay() && <div className={`${styles["side-nav-bar"]} dock`}>      
           {buttonNames.map((buttonName, buttonIndex)=>{

--- a/frontend/src/components/ViewMenuItemModal.tsx
+++ b/frontend/src/components/ViewMenuItemModal.tsx
@@ -1,18 +1,19 @@
 import React from 'react'
 import Image from 'next/image'
 import {MenuItemProps} from './MenuItem'
+import viewModalStyles from '../styles/ViewMenuItemModal.module.css'
 
 export default function ViewMenuItemModal(modalDetails: MenuItemProps) {
     const imgSize = 300;
     console.log(modalDetails)
   return (
-    <span className="flex fixed w-full h-full bg-[--white-backdrop] items-center justify-center top-0 left-0 backdrop-blur-sm"
+    <span className={viewModalStyles["view-menu-item-modal"]}
         onKeyDown={(e)=> {
             if(e.key ==='Escape' && modalDetails.modalToggle) modalDetails.modalToggle()
         }}
     >
-        <span className="flex relative bg-white m-4 px-[50px] rounded-[10px]  py-[40px] outline">
-        <button className="btn absolute bg-[--foreground] border-none top-[20px] text-white right-[20px]" onClick={modalDetails.modalToggle}
+        <span className={viewModalStyles["inner-contents-container"]}>
+        <button className={viewModalStyles["exit-button"]} onClick={modalDetails.modalToggle}
             >Exit</button>
             {modalDetails.picture &&<Image
                 src={modalDetails.picture}
@@ -20,12 +21,12 @@ export default function ViewMenuItemModal(modalDetails: MenuItemProps) {
                 height={imgSize}
                 alt="an image"
             />}
-            <span className="flex flex-col justify-center ">
-                <h1 className="text-[1.2rem] font-semibold mb-[10px] max-w-[200px]">{modalDetails.name}</h1>
+            <span className={viewModalStyles["product-details-container"]}>
+                <h1 className="text-[1.2rem] font-semibold mb-[10px] max-w-[200px] mobile:text-center">{modalDetails.name}</h1>
                 <p className="text-black">ID: {modalDetails.id}</p>
                 <p className="text-[1rem] font-semibold text-black">Price: ${modalDetails.price}</p> 
                 <h2 className="text-[1rem] font-semibold text-black underline">Ingredients:</h2>
-                <ul className="text-black">
+                <ul className={viewModalStyles["ingredients-list-container"]}>
                     {modalDetails.ingredients?.map((ingredient, index)=>{
                         return <li key={index}>{ingredient.ingredients.ingredientname}</li>
                     })}

--- a/frontend/src/components/ViewMenuItemModal.tsx
+++ b/frontend/src/components/ViewMenuItemModal.tsx
@@ -5,7 +5,6 @@ import viewModalStyles from '../styles/ViewMenuItemModal.module.css'
 
 export default function ViewMenuItemModal(modalDetails: MenuItemProps) {
     const imgSize = 300;
-    console.log(modalDetails)
   return (
     <span className={viewModalStyles["view-menu-item-modal"]}
         onKeyDown={(e)=> {
@@ -32,8 +31,7 @@ export default function ViewMenuItemModal(modalDetails: MenuItemProps) {
                     })}
                 </ul>               
             </span>
-        </span>
-        
+        </span>        
     </span>
   )
 }

--- a/frontend/src/styles/Cart.module.css
+++ b/frontend/src/styles/Cart.module.css
@@ -1,12 +1,10 @@
-@keyframes slide-from-right {
-    0%{transform: translateX(120%);}
-    100%{transform: translateX(0);}    
-}
+
 .cart-container{
     @apply flex fixed right-[10px] flex-col px-[40px] gap-[1rem];
     @apply py-[20px] rounded-[8px] max-w-[500px] min-w-[300px] bg-white h-[80%] outline;
     @apply justify-evenly top-[100px] mobile:min-w-full mobile:right-0 mobile:rounded-none tablet:bottom-[10px] tablet:top-[unset];
-    animation: slide-from-right 0.3s cubic-bezier(0.20, -0.9, 0.10, 1.8);
+    @starting-style{transform: translateX(120%);}
+    transition: transform 0.4s cubic-bezier(0.20, -0.9, 0.10, 1.2);
 }
 
 .pos-item-name{

--- a/frontend/src/styles/MenuItem.module.css
+++ b/frontend/src/styles/MenuItem.module.css
@@ -4,9 +4,16 @@
     @apply mobile:max-w-[100%];
 }
 .pos-menu-item{
+    --transition-delay: 0;
     @apply grid relative place-items-center rounded-[6px] flex-col max-w-[1fr] h-[200px] p-[20px] bg-[white] overflow-clip gap-[4px];
     box-shadow: 0 0px 4px 2px var(--drop-shadow-color);
     @apply mobile:w-[100%] mobile:p-[5px] mobile:max-w-[80%];   
+    @starting-style{
+        opacity: 0;
+        transform: translatex(-40%) scale(0);
+    }
+    transition: all 0.2s cubic-bezier(0.5, 1.5, 0.5, 1);
+    transition-delay: var(--transition-delay);
 }
 
 .menuItem button {

--- a/frontend/src/styles/MenuItem.module.css
+++ b/frontend/src/styles/MenuItem.module.css
@@ -1,7 +1,7 @@
 .menuItem {
-    @apply grid relative rounded-[6px] flex-col max-w-[160px] h-[200px] p-[20px] bg-[white] overflow-y-clip gap-[8px] justify-between;
-    box-shadow: 0 0px 4px 2px var(--drop-shadow-color);
-    @apply mobile:max-w-[100%];
+    @apply grid relative rounded-[6px] flex-col max-w-[200px] h-[200px] p-[20px] bg-[white] overflow-y-clip gap-[8px] justify-between;
+    @apply place-items-center mobile:max-w-[1fr];
+    box-shadow: 0 0px 4px 2px var(--drop-shadow-color);   
 }
 .pos-menu-item{
     --transition-delay: 0;
@@ -42,7 +42,7 @@
 }
 
 .menuItemName {
-    @apply text-[1.1rem] max-h-[250px] overflow-y-auto;
+    @apply text-center text-[1.1rem] overflow-y-auto;
 }
 .menu-item-name-pos{
     @apply tablet:text-[1rem] text-center mobile:mb-[-10px] font-semibold;

--- a/frontend/src/styles/MenuManagementContainer.module.css
+++ b/frontend/src/styles/MenuManagementContainer.module.css
@@ -10,11 +10,10 @@
 }
 .restaurant-current-option-title > span{ @apply font-semibold;}
 .restaurant-components-main-container {@apply flex flex-col items-center;}
-.restaurant-main-food-menu-container {@apply mb-[4rem];}
 .restaurant-sub-menu-container {
-    @apply grid gap-2 grid-cols-3 grid-rows-2 p-[20px] mb-[10px] bg-white rounded-[8px];
+    @apply grid gap-2 grid-cols-3 grid-rows-2 p-[20px] mb-[10px] mt-[50px] bg-white rounded-[8px];
     @apply tablet:p-[10px] tablet:w-[90dvw];
-    @apply mobile:grid-cols-2 mobile:w-[90dvw];
+    @apply mobile:grid-cols-2 mobile:max-h-[200px] overflow-y-scroll;
     box-shadow: var(--sellers-container-drop-shadow);
 }
 .restaurant-sub-menu-button {
@@ -29,8 +28,8 @@
   }
 
   .current-menu-items-container {
-    @apply grid grid-cols-4 pt-[20px] pb-[40px] gap-[20px] max-h-[600px] px-[20px] overflow-y-scroll max-w-[100%] mb-[50px];
-    @apply mobile:grid-cols-1 mobile-m:grid-cols-2 mobile:w-[90dvw] tablet:grid-cols-3;
+    @apply grid grid-cols-4 pt-[20px] gap-[20px] max-h-[600px] px-[20px] overflow-y-scroll max-w-[100%];
+    @apply mobile:grid-cols-1  mobile:w-[100%] mobile:px-[20px] tablet:grid-cols-3;
     place-items: center; 
   }
 
@@ -38,4 +37,8 @@
     @apply grid grid-flow-row-dense tablet:grid-cols-2 mb-[100px];
     @apply p-[20px] grid-cols-3 gap-[20px] max-h-[600px] overflow-y-auto;
     @apply tablet:grid-cols-2 tablet:self-baseline mobile:grid-cols-1 mobile:w-[100%] mobile:place-items-center;
+  }
+
+  .restaurant-parent-container{
+    @apply flex flex-col w-full justify-center items-center mobile:mt-[100px];
   }

--- a/frontend/src/styles/MenuManagementContainer.module.css
+++ b/frontend/src/styles/MenuManagementContainer.module.css
@@ -13,7 +13,7 @@
 .restaurant-sub-menu-container {
     @apply grid gap-2 relative grid-cols-3 grid-rows-2 p-[20px] mb-[10px] mt-[50px] bg-white rounded-[8px];
     @apply tablet:p-[10px] tablet:w-[90dvw];
-    @apply mobile:grid-cols-1 mobile:max-h-[200px] overflow-y-scroll mobile:grid-rows-[auto];
+    @apply mobile:grid-cols-1 mobile:max-h-[200px] mobile:overflow-y-scroll mobile:grid-rows-[auto];
     box-shadow: var(--sellers-container-drop-shadow);
 }
 .restaurant-sub-menu-button {

--- a/frontend/src/styles/MenuManagementContainer.module.css
+++ b/frontend/src/styles/MenuManagementContainer.module.css
@@ -11,15 +11,15 @@
 .restaurant-current-option-title > span{ @apply font-semibold;}
 .restaurant-components-main-container {@apply flex flex-col items-center;}
 .restaurant-sub-menu-container {
-    @apply grid gap-2 grid-cols-3 grid-rows-2 p-[20px] mb-[10px] mt-[50px] bg-white rounded-[8px];
+    @apply grid gap-2 relative grid-cols-3 grid-rows-2 p-[20px] mb-[10px] mt-[50px] bg-white rounded-[8px];
     @apply tablet:p-[10px] tablet:w-[90dvw];
-    @apply mobile:grid-cols-2 mobile:max-h-[200px] overflow-y-scroll;
+    @apply mobile:grid-cols-1 mobile:max-h-[200px] overflow-y-scroll mobile:grid-rows-[auto];
     box-shadow: var(--sellers-container-drop-shadow);
 }
 .restaurant-sub-menu-button {
     @apply text-[--foreground] text-center text-[1.3rem] cursor-pointer rounded-[8px]  px-[35px] py-[25px] bg-white border-none;
     @apply tablet:text-[1rem] tablet:px-[5px];
-    @apply mobile:text-[1.4rem] mobile:py-[30px] mobile:px-[10px];
+    @apply mobile:text-[1.2rem] mobile:gap-y-4 mobile:py-[20px] mobile:px-[10px];
     box-shadow: var(--sellers-container-drop-shadow);
     &:hover {
       @apply !text-white !bg-[--foreground];

--- a/frontend/src/styles/OrderDetailsScreen.module.css
+++ b/frontend/src/styles/OrderDetailsScreen.module.css
@@ -1,17 +1,28 @@
-.order-details-container{
-    @apply flex fixed text-[--foreground-color] bg-white rounded-[8px] outline;
-    @apply flex-col gap-[0.6rem] pt-[10px] pb-[40px] justify-center;    
-    z-index: 100;
-    top: 16%;
-}
 .order-details-container-bg{
-    @apply bg-[#ffffff91] fixed w-full h-full;
+    @apply bg-[#2b2b2b6b] fixed w-full h-full;
     content: "";
     backdrop-filter: blur(10px);
     top: 0;
     left: 0;
-    z-index: -1;
+    z-index: 10;
+    @starting-style{
+        opacity: 0.5;
+    }
+    transition: all 0.3s cubic-bezier(0.95, 0.05, 0.795, 0.035);
  }
+
+.order-details-container{
+    @apply flex fixed text-[--foreground-color] bg-white rounded-[8px] outline;
+    @apply flex-col gap-[0.6rem] pt-[10px] pb-[40px] justify-center mobile:px-[10px];    
+    z-index: 1000;
+    top: 16%;
+    @starting-style{
+        transform: scale(1.4);
+        opacity: 0;
+    }
+    transition: all 0.5s cubic-bezier(0.645, 0.045, 0.355, 1); 
+}
+
 .order-details-title{
     @apply flex self-center text-[1.6rem] font-semibold;
     grid-area: order-details-title;

--- a/frontend/src/styles/OrderReceiptManager.module.css
+++ b/frontend/src/styles/OrderReceiptManager.module.css
@@ -1,8 +1,15 @@
 .current-order-items-manager {
+    --trans-delay: 0s;
     @apply flex flex-col w-[300px] gap-[1rem] p-[40px] rounded-[8px] bg-white ;
     @apply p-[20px];
     @apply mobile:w-full;
     box-shadow: 0 0 4px 4px var(--drop-shadow-color);
+    @starting-style{
+        opacity: 0;
+        transform: translatey(100%);
+    }
+    transition: all 0.4s cubic-bezier(0.05, 1.8, 0.9, 0.9);
+    transition-delay: var(--trans-delay);
 }
 .order-header-group {
     @apply flex flex-col justify-between;

--- a/frontend/src/styles/OrderTracking.module.css
+++ b/frontend/src/styles/OrderTracking.module.css
@@ -1,0 +1,9 @@
+.order-receipt-container{
+    @apply carousel max-h-[fit-content] justify-start align-middle overflow-x-auto p-[2rem] rounded-box bg-neutral;
+    @apply gap-[1rem] carousel-start w-full scroll-smooth outline mobile:w-full mobile:carousel-vertical;
+    @apply mobile:rounded-none mobile:items-center mobile:p-[2rem] tablet:pt-[10px] tablet:mb-[4rem];
+}
+.order-tracking-container{
+    @apply flex max-w-[80dvw] justify-center mt-[20px];
+    @apply mobile:max-w-full mobile:mb-[4rem];
+}

--- a/frontend/src/styles/ViewMenuItemModal.module.css
+++ b/frontend/src/styles/ViewMenuItemModal.module.css
@@ -1,0 +1,26 @@
+
+.view-menu-item-modal{
+    @apply flex fixed w-full h-full bg-[--white-backdrop] items-center justify-center top-0 left-0 backdrop-blur-sm;
+    @apply mobile:flex-col;
+    @starting-style{
+        transform: scale(1.4);
+        opacity: 0;
+    }
+    transition: all 0.5s cubic-bezier(0.645, 0.045, 0.355, 1); 
+}
+.ingredients-list-container{
+    @apply text-black mobile:h-[100px] overflow-y-auto;
+
+}
+.exit-button{
+    @apply btn absolute bg-[--foreground] border-none top-[20px] text-white right-[20px];
+}
+
+.product-details-container{
+    @apply flex flex-col justify-center mobile:mt-[10px];
+}
+
+.inner-contents-container{
+    @apply flex relative bg-white m-4 px-[50px] rounded-[10px]  py-[40px] outline;
+    @apply mobile:flex-col mobile:place-items-center;
+}


### PR DESCRIPTION
This pr addresses a good amount of pain point that are now mostly gone:

1. Mobile selectable menu is now a column with scrolling for a smoother experience.
2. Both the POS menu items and the menu management page menu items have been worked on to work well on all different screen sizes.
3. POS cart button background color now matches the go back to portal button's bg color.
4. The menu management view item modal now works as intended on mobile.
5. POS cart now doesn't display on mobile screens when first visited.
6. I've applied some starting style transitions for some of the components in pages to come into display in a sequence.
7. I've added the brand colors to the globals.css file. 
8. I've created a new css module  for the view item component.
9. The pos top buttons have been moved down the file to help with some z-index issues.
10. View order details screen now displays the correct cost instead of hardcoded values and has a starting transition.