### PR TITLE
Cr183 fe make order details modal fit on mobile devices

### DIFF
--- a/frontend/src/components/OrderDetailsScreen.tsx
+++ b/frontend/src/components/OrderDetailsScreen.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import styles from "../styles/OrderDetailsScreen.module.css";
 import { Order } from "./OrderReceiptManager";
+import scrollBarToggle from "./scrollBarToggle";
 
 export interface OrderDetails{
   order: Order | null,
@@ -12,12 +13,16 @@ export default function OrderDetailsScreen(orderDetails: OrderDetails) {
   const disableModal =()=>{
     orderDetails.updateOrderDetailsScreen(null)
   }
+  scrollBarToggle(false)
   const orderTotal = oDetails?.orderitems.reduce((acc, curr)=>{ return acc + parseFloat(curr.menuitems.price.toString())},0)
   const tax = parseFloat(((Math.random() * 10) + 1).toFixed(2));
   const finalPrice = orderTotal? (tax + orderTotal).toFixed(2): 0;
   return (
     <>
-      <span className={styles["order-details-container-bg"]} onClick={disableModal}></span>
+      <span className={styles["order-details-container-bg"]} onClick={()=>{
+        scrollBarToggle(true)
+        disableModal()
+      }}></span>
       <dialog className={styles["order-details-container"]} 
       onLoadStart={(e)=> e.currentTarget.focus()}
       onKeyDown={(e)=> {

--- a/frontend/src/components/OrderDetailsScreen.tsx
+++ b/frontend/src/components/OrderDetailsScreen.tsx
@@ -11,6 +11,7 @@ export interface OrderDetails{
 export default function OrderDetailsScreen(orderDetails: OrderDetails) {
   const oDetails = orderDetails.order  
   const disableModal =()=>{
+    scrollBarToggle(true)
     orderDetails.updateOrderDetailsScreen(null)
   }
   scrollBarToggle(false)
@@ -19,8 +20,7 @@ export default function OrderDetailsScreen(orderDetails: OrderDetails) {
   const finalPrice = orderTotal? (tax + orderTotal).toFixed(2): 0;
   return (
     <>
-      <span className={styles["order-details-container-bg"]} onClick={()=>{
-        scrollBarToggle(true)
+      <span className={styles["order-details-container-bg"]} onClick={()=>{        
         disableModal()
       }}></span>
       <dialog className={styles["order-details-container"]} 
@@ -33,12 +33,12 @@ export default function OrderDetailsScreen(orderDetails: OrderDetails) {
         <button className={styles["exit-button"]}
         onClick={disableModal}
         >Exit</button>
-        <span className="flex gap-[1rem] mt-[40px] justify-center">        
+        <span className= {styles["info-panels-container"]}>        
           <span className={styles["full-order-details-container"]}>
             <span className={styles["order-details-header"]}>
-              <p>Restaurant Name</p>
+              <p>Chicken Queen</p>
               <p>Order #{oDetails?.orderid}</p>
-              <p>Order Date</p>
+              <p>Order Date: {orderDetails.order?.timePlaced}</p>
             </span>
             <span className={styles["items-list-container"]}>
               {oDetails?.orderitems && oDetails?.orderitems.map((elem, index)=>{
@@ -57,8 +57,13 @@ export default function OrderDetailsScreen(orderDetails: OrderDetails) {
             </span>
             <span className={styles["message-and-payment-method-container"]}>
               <p>Payment Method:</p>
-              <p>Credit Card(**** 2394)</p>
-              <p>{`Thank you for choosing Cluckin' Good Chicken! Have a cluckin' great day! 🐔`}</p>
+              <select name="payment-method" id={styles["payment-method"]}>
+                <option value="credit-card">Credit Card (**** 2394)</option>
+                <option value="Debit-debit">Debit Card (**** 4596)</option>
+                <option value="cash">Cash</option>
+                <option value="payPal">Paypal</option>
+              </select>
+              <p>{`Thank you for choosing Chicken Queen Chicken! Have a great day! 👑🐔`}</p>
             </span>
           </span>
           <span className={styles["modify-order-container"]}>
@@ -75,7 +80,7 @@ export default function OrderDetailsScreen(orderDetails: OrderDetails) {
                 Mark Refunded / Dissatisfied
               </button>
             </span>
-            <button className="btn w-[max-content] bg-[--foreground] border-none text-white"
+            <button className={styles["print-receipt-button"]}
               onClick={()=> window.print()}
             >
               Print Receipt

--- a/frontend/src/components/OrderDetailsScreen.tsx
+++ b/frontend/src/components/OrderDetailsScreen.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import styles from "../styles/OrderDetailsScreen.module.css";
 import { Order } from "./OrderReceiptManager";
 import scrollBarToggle from "./scrollBarToggle";
+import { LocaleRouteNormalizer } from "next/dist/server/normalizers/locale-route-normalizer";
 
 export interface OrderDetails{
   order: Order | null,
@@ -18,6 +19,7 @@ export default function OrderDetailsScreen(orderDetails: OrderDetails) {
   const orderTotal = oDetails?.orderitems.reduce((acc, curr)=>{ return acc + parseFloat(curr.menuitems.price.toString())},0)
   const tax = parseFloat(((Math.random() * 10) + 1).toFixed(2));
   const finalPrice = orderTotal? (tax + orderTotal).toFixed(2): 0;
+  const orderTimeStamp = new Date(oDetails?.ordertimestamp || "").toLocaleString("en-US", { timeZone: "UTC" })
   return (
     <>
       <span className={styles["order-details-container-bg"]} onClick={()=>{        
@@ -38,7 +40,7 @@ export default function OrderDetailsScreen(orderDetails: OrderDetails) {
             <span className={styles["order-details-header"]}>
               <p>Chicken Queen</p>
               <p>Order #{oDetails?.orderid}</p>
-              <p>Order Date: {orderDetails.order?.timePlaced}</p>
+              <p>Order Date: {orderTimeStamp.split(",")[0]}</p>
             </span>
             <span className={styles["items-list-container"]}>
               {oDetails?.orderitems && oDetails?.orderitems.map((elem, index)=>{
@@ -58,10 +60,10 @@ export default function OrderDetailsScreen(orderDetails: OrderDetails) {
             <span className={styles["message-and-payment-method-container"]}>
               <p>Payment Method:</p>
               <select name="payment-method" id={styles["payment-method"]}>
-                <option value="credit-card">Credit Card (**** 2394)</option>
-                <option value="Debit-debit">Debit Card (**** 4596)</option>
-                <option value="cash">Cash</option>
-                <option value="payPal">Paypal</option>
+                <option className={styles["option-selection"]} value="credit-card">Credit Card (**** 2394)</option>
+                <option className={styles["option-selection"]} value="Debit-debit">Debit Card (**** 4596)</option>
+                <option className={styles["option-selection"]} value="cash">Cash</option>
+                <option className={styles["option-selection"]} value="payPal">PayPal</option>
               </select>
               <p>{`Thank you for choosing Chicken Queen Chicken! Have a great day! 👑🐔`}</p>
             </span>

--- a/frontend/src/components/OrderDetailsScreen.tsx
+++ b/frontend/src/components/OrderDetailsScreen.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import styles from "../styles/OrderDetailsScreen.module.css";
 import { Order } from "./OrderReceiptManager";
 import scrollBarToggle from "./scrollBarToggle";
-import { LocaleRouteNormalizer } from "next/dist/server/normalizers/locale-route-normalizer";
 
 export interface OrderDetails{
   order: Order | null,

--- a/frontend/src/components/scrollBarToggle.tsx
+++ b/frontend/src/components/scrollBarToggle.tsx
@@ -1,0 +1,12 @@
+export default function scrollBarToggle(isScrollingEnabled: boolean) {
+        if(typeof window === 'undefined') return
+        const body = document.body
+        if(!isScrollingEnabled){
+            body.style.height = "100%"
+            body.style.overflowY = "hidden"
+        }
+        else{
+            body.style.height = "revert"
+            body.style.overflowY = "auto"
+        }
+}

--- a/frontend/src/styles/OrderDetailsScreen.module.css
+++ b/frontend/src/styles/OrderDetailsScreen.module.css
@@ -12,10 +12,11 @@
  }
 
 .order-details-container{
-    @apply flex fixed text-[--foreground-color] bg-white rounded-[8px] outline;
-    @apply flex-col gap-[0.6rem] pt-[10px] pb-[40px] justify-center mobile:px-[10px];    
-    z-index: 1000;
-    top: 16%;
+    @apply flex fixed  top-[20px] text-[--foreground-color] bg-[--color] rounded-[8px] outline;
+    @apply flex-col gap-[0.6rem] pt-[10px] pb-[40px] justify-center overflow-y-auto;    
+    @apply  mobile:overflow-y-auto mobile:top-[10px] mobile:rounded-none mobile:left-0 mobile:pb-0 mobile:px-[10px];
+    z-index: var(--top-most-z-index);
+    
     @starting-style{
         transform: scale(1.4);
         opacity: 0;
@@ -25,17 +26,18 @@
 
 .order-details-title{
     @apply flex self-center text-[1.6rem] font-semibold;
-    grid-area: order-details-title;
 }
 
 .exit-button{
     @apply btn top-[10px];
     @apply border-none bg-[--custom-active-red-color] rounded-[4px] text-white absolute right-[20px];
-    grid-area: exit-button;    
+    @apply mobile:w-[fit-content] mobile:right-[5px];
 }
 
 .modify-order-container{
-    @apply flex items-center gap-[40px] flex-col justify-center outline w-[400px] rounded-[10px] p-[20px];
+    @apply flex items-center bg-[--color] gap-[20px] mb-[30px] flex-col justify-center outline max-h-[fit-content] w-[400px] rounded-[4px] p-[20px];
+    @apply mobile:absolute mobile:max-w-[fit-content]  mobile:max-h-[fit-content];
+    @apply mobile:self-center mobile:p-[5px] mobile:gap-[20px] mobile:bottom-[-52%];
 }
 
 .modify-order-button{
@@ -43,7 +45,8 @@
 }
 
 .full-order-details-container{
-    @apply flex flex-col max-w-[50%] gap-y-[0.4rem] max-h-[500px] overflow-y-auto;
+    @apply flex flex-col max-w-[50%] gap-y-[0.4rem] max-h-[100%];
+    @apply mobile:max-w-[80%] mobile:overflow-y-scroll;
 }
 .full-order-details-container > * :is(:not(.items-list-container)){
     @apply grid gap-y-[0.2rem]; 
@@ -64,13 +67,27 @@
 }
 
 .items-list-container{
-    @apply flex gap-y-[10px] mx-[10px] py-[10px] my-[20px] rounded-[4px] p-[10px] flex-col h-[400px] overflow-y-auto outline;
+    @apply flex gap-y-[10px] mx-[10px] my-[20px] rounded-[4px] p-[10px] flex-col h-[300px] overflow-y-auto outline;
 }
 
 .items-list-container li{
-    @apply pl-[5px] border-b-4;
+    @apply pl-[5px];
 }
 
 .items-list-container ul{
     @apply list-disc;
 }
+
+.info-panels-container{
+    @apply flex relative gap-[1rem] mt-[20px] justify-center items-center ;
+    @apply mobile:flex-col mobile:max-w-[100%] mobile:max-h-[40%] mobile:overflow-y-scroll mobile:mt-[10px];
+}
+
+#payment-method{
+    @apply bg-[inherit] px-[5px] mx-[5px] py-[5px];
+}
+
+.print-receipt-button{
+    @apply btn w-[max-content] bg-[--foreground] border-none text-white;
+}
+

--- a/frontend/src/styles/OrderDetailsScreen.module.css
+++ b/frontend/src/styles/OrderDetailsScreen.module.css
@@ -14,6 +14,7 @@
 .order-details-container{
     @apply flex fixed  top-[20px] text-[--foreground-color] bg-[--color] rounded-[8px] outline;
     @apply flex-col gap-[0.6rem] pt-[10px] pb-[40px] justify-center overflow-y-auto;    
+    @apply tablet:px-[20px];
     @apply  mobile:overflow-y-auto mobile:top-[10px] mobile:rounded-none mobile:left-0 mobile:pb-0 mobile:px-[10px];
     z-index: var(--top-most-z-index);
     
@@ -84,7 +85,8 @@
 }
 
 #payment-method{
-    @apply bg-[inherit] px-[5px] mx-[5px] py-[5px];
+    @apply bg-[inherit] px-[5px] mx-[5px] py-[5px] hover:cursor-pointer hover:bg-[--foreground] hover:text-[--color];
+    transition: all 0.2s cubic-bezier(0.075, 0.82, 0.165, 1);
 }
 
 .print-receipt-button{

--- a/frontend/src/styles/OrderDetailsScreen.module.css
+++ b/frontend/src/styles/OrderDetailsScreen.module.css
@@ -85,11 +85,13 @@
 }
 
 #payment-method{
-    @apply bg-[inherit] px-[5px] mx-[5px] py-[5px] hover:cursor-pointer hover:bg-[--foreground] hover:text-[--color];
+    @apply bg-[inherit] px-[5px] mx-[5px] py-[5px] hover:cursor-pointer;
     transition: all 0.2s cubic-bezier(0.075, 0.82, 0.165, 1);
 }
 
 .print-receipt-button{
     @apply btn w-[max-content] bg-[--foreground] border-none text-white;
 }
-
+.option-selection{
+    @apply bg-[--color];
+}


### PR DESCRIPTION
The order details modal is now better for mobile and tablets. Since there's not that much time left, I'll just go ahead and leave it like this.

![image](https://github.com/user-attachments/assets/5f7f5d1e-37f6-4e82-95bd-aa9c8715fe08)
![image](https://github.com/user-attachments/assets/2b415178-cf17-4938-bfe2-f601cb85e12e)

it can scroll vertically just fine.