### PR TITLE
CRM-189 FE Item prices on the Order Details screen doesn't always show two decimal places

### DIFF
--- a/frontend/src/components/OrderDetailsScreen.tsx
+++ b/frontend/src/components/OrderDetailsScreen.tsx
@@ -45,8 +45,8 @@ export default function OrderDetailsScreen(orderDetails: OrderDetails) {
               {oDetails?.orderitems && oDetails?.orderitems.map((elem, index)=>{
                   return(
                       <ul key={index}>
-                          <li>Order Name {elem.menuitems.name}</li>
-                          <li>${elem.menuitems.price}</li>
+                      <li>Order Name {elem.menuitems.name}</li>
+                          <li>${Number(elem.menuitems.price)}</li>
                       </ul>
                   )
               })}

--- a/frontend/src/components/OrderDetailsScreen.tsx
+++ b/frontend/src/components/OrderDetailsScreen.tsx
@@ -46,7 +46,7 @@ export default function OrderDetailsScreen(orderDetails: OrderDetails) {
                   return(
                       <ul key={index}>
                       <li>Order Name {elem.menuitems.name}</li>
-                          <li>${Number(elem.menuitems.price)}</li>
+                          <li>${Number(elem.menuitems.price).toFixed(2)}</li>
                       </ul>
                   )
               })}


### PR DESCRIPTION
On line 49 in the OrderDetailsScreen.tsx component, I enclosed elem.menuitem.price inside of Number().toFixed(2) so that item prices will always show 2 decimal places. Before, they would only show one decimal place if the second was 0.