### PR TITLE
CRM-191 FE Make all menu item prices show two decimal places on the POS

### DIFF
--- a/frontend/src/app/pos/page.tsx
+++ b/frontend/src/app/pos/page.tsx
@@ -156,7 +156,7 @@ export default function POS() {
                   {item.name}
                 </p>
                 <span className={menuItemStyles["menu-item-price-pos"]}>
-                  <p>Price: ${item.price}</p>                  
+                  <p>Price: ${Number(item.price).toFixed(2)}</p>                  
                 </span>
                 <button
                   className={menuItemStyles["add-item-button-pos"]}


### PR DESCRIPTION
In the POS page.tsx, wrapped item.price on line 159 inside Number().toFixed(2) so that item prices always show 2 decimal places.